### PR TITLE
Add minimal UI implementations for map and shell scenes

### DIFF
--- a/src/scenes/MapScene.ts
+++ b/src/scenes/MapScene.ts
@@ -1,0 +1,41 @@
+import { ModuleScene } from '@core/Router';
+
+export default class MapScene extends ModuleScene {
+  constructor() {
+    super('MapScene');
+  }
+
+  create() {
+    const { width, height } = this.scale;
+
+    this.add
+      .text(width / 2, height / 2, '這裡會列出可去地點與可啟動劇情', {
+        fontSize: '20px',
+        color: '#fff'
+      })
+      .setOrigin(0.5);
+
+    const saveMessage = this.add
+      .text(16, height - 16, '', {
+        fontSize: '16px',
+        color: '#fff'
+      })
+      .setOrigin(0, 1);
+
+    const saveButton = this.add
+      .text(width - 16, 16, '存檔', {
+        fontSize: '18px',
+        color: '#aaf'
+      })
+      .setOrigin(1, 0)
+      .setInteractive({ useHandCursor: true });
+
+    saveButton.on('pointerup', () => {
+      const saver = this.registry.get('saver');
+      if (saver && typeof saver.save === 'function') {
+        saver.save(0);
+      }
+      saveMessage.setText('已存檔');
+    });
+  }
+}

--- a/src/scenes/ShellScene.ts
+++ b/src/scenes/ShellScene.ts
@@ -1,12 +1,34 @@
 import { ModuleScene } from '@core/Router';
+
 export default class ShellScene extends ModuleScene {
-  constructor(){ super('ShellScene'); }
-  create(){
+  constructor() {
+    super('ShellScene');
+  }
+
+  create() {
+    const { width, height } = this.scale;
     const world = this.registry.get('world');
-    this.add.text(16,16, ()=>`位置：${world.data.位置}  煞氣：${world.data.煞氣}  陰德：${world.data.陰德}`, {color:'#fff'}).setDepth(10);
-    const toMap = this.add.text(16, 50, '前往地圖', {color:'#aaf'}).setInteractive();
-    toMap.on('pointerup', async ()=>{
-      await this.registry.get('router').push('MapScene', {});
+    const location = world?.data?.位置 ?? '';
+    const sha = world?.data?.煞氣 ?? '';
+    const yin = world?.data?.陰德 ?? '';
+
+    this.add
+      .text(16, 16, `位置：${location}\n煞氣：${sha}\n陰德：${yin}`, {
+        fontSize: '16px',
+        color: '#fff'
+      })
+      .setOrigin(0, 0);
+
+    const mapButton = this.add
+      .text(width / 2, height / 2, '開啟地圖', {
+        fontSize: '24px',
+        color: '#aaf'
+      })
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true });
+
+    mapButton.on('pointerup', () => {
+      this.registry.get('router').push('MapScene');
     });
   }
 }

--- a/src/scenes/TitleScene.ts
+++ b/src/scenes/TitleScene.ts
@@ -1,14 +1,35 @@
 import { ModuleScene } from '@core/Router';
-export default class TitleScene extends ModuleScene<void,{action:"new"|"load",slot?:number}>{
-  constructor(){ super('TitleScene'); }
-  create(){
-    const w = this.scale.width, h = this.scale.height;
-    this.add.text(w/2, h/2-40, '靈媒：意識流字卡', { fontSize:'32px', color:'#fff' }).setOrigin(0.5);
-    const start = this.add.text(w/2, h/2+10, '開始新遊戲', { fontSize:'20px', color:'#aaf' }).setOrigin(0.5).setInteractive();
-    const load  = this.add.text(w/2, h/2+50, '讀取進度', { fontSize:'20px', color:'#aaf' }).setOrigin(0.5).setInteractive();
 
-    start.on('pointerup', ()=> this.done({action:'new'}));
-    load.on('pointerup',  ()=> this.done({action:'load', slot:0}));
+export default class TitleScene extends ModuleScene<void, { action: 'new' | 'load'; slot?: number }> {
+  constructor() {
+    super('TitleScene');
   }
-  shutdown(){ /* no-op */ }
+
+  create() {
+    const w = this.scale.width,
+      h = this.scale.height;
+    this.add.text(w / 2, h / 2 - 40, '靈媒：意識流字卡', { fontSize: '32px', color: '#fff' }).setOrigin(0.5);
+    const start = this.add
+      .text(w / 2, h / 2 + 10, '開始新遊戲', { fontSize: '20px', color: '#aaf' })
+      .setOrigin(0.5)
+      .setInteractive();
+    const load = this.add
+      .text(w / 2, h / 2 + 50, '讀取進度', { fontSize: '20px', color: '#aaf' })
+      .setOrigin(0.5)
+      .setInteractive();
+
+    start.on('pointerup', () => this.done({ action: 'new' }));
+    load.on('pointerup', () => this.done({ action: 'load', slot: 0 }));
+  }
+
+  protected override done(result: { action: 'new' | 'load'; slot?: number }) {
+    super.done(result);
+    if (result.action === 'new') {
+      this.scene.start('ShellScene');
+    }
+  }
+
+  shutdown() {
+    /* no-op */
+  }
 }


### PR DESCRIPTION
## Summary
- implement a minimal MapScene with placeholder content, save button, and confirmation text
- update ShellScene to show HUD stats and provide a button to open the map
- adjust TitleScene so starting a new game transitions directly to ShellScene

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d760f1b9ec832e8e32b970b268d8bc