### PR TITLE
Add inventory selection scene

### DIFF
--- a/src/scenes/InventoryScene.ts
+++ b/src/scenes/InventoryScene.ts
@@ -1,0 +1,72 @@
+import { ModuleScene } from '@core/Router';
+import type { DataRepo } from '@core/DataRepo';
+
+type ItemData = {
+  id: string;
+  '名'?: string;
+  '來源'?: string;
+  '用途'?: string[];
+};
+
+export default class InventoryScene extends ModuleScene<void, string | null> {
+  constructor() {
+    super('InventoryScene');
+  }
+
+  async create() {
+    const repo = this.registry.get('repo') as DataRepo | undefined;
+    const { width, height } = this.scale;
+
+    this.add.text(width / 2, 48, '物品列表', { fontSize: '28px', color: '#fff' }).setOrigin(0.5);
+
+    let selectedItemId: string | null = null;
+    const selectedLabel = this.add
+      .text(width / 2, height - 140, '目前選擇：無', { fontSize: '18px', color: '#fff' })
+      .setOrigin(0.5);
+
+    const closeButton = this.add
+      .text(width / 2, height - 80, '關閉並回傳選到的物品 id（或 null）', {
+        fontSize: '20px',
+        color: '#aaf'
+      })
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true });
+
+    closeButton.on('pointerup', () => {
+      this.done(selectedItemId ?? null);
+    });
+
+    if (!repo) {
+      selectedLabel.setText('目前選擇：資料庫不可用');
+      closeButton.setStyle({ color: '#faa' });
+      return;
+    }
+
+    const items = await repo.get<ItemData[]>('items');
+    const itemEntries: { id: string; text: Phaser.GameObjects.Text }[] = [];
+
+    const updateSelection = () => {
+      itemEntries.forEach(({ id, text }) => {
+        text.setStyle({ color: id === selectedItemId ? '#ff0' : '#aaf' });
+      });
+      selectedLabel.setText(`目前選擇：${selectedItemId ?? '無'}`);
+    };
+
+    items.forEach((item, index) => {
+      const label = `${item['名'] ?? item.id}`;
+      const itemText = this.add
+        .text(width / 2, 120 + index * 36, label, { fontSize: '20px', color: '#aaf' })
+        .setOrigin(0.5)
+        .setInteractive({ useHandCursor: true });
+
+      itemText.on('pointerup', () => {
+        selectedItemId = item.id;
+        updateSelection();
+      });
+
+      itemEntries.push({ id: item.id, text: itemText });
+    });
+
+    updateSelection();
+  }
+}

--- a/src/scenes/ShellScene.ts
+++ b/src/scenes/ShellScene.ts
@@ -1,4 +1,4 @@
-import { ModuleScene } from '@core/Router';
+import { ModuleScene, Router } from '@core/Router';
 
 export default class ShellScene extends ModuleScene {
   constructor() {
@@ -8,6 +8,7 @@ export default class ShellScene extends ModuleScene {
   create() {
     const { width, height } = this.scale;
     const world = this.registry.get('world');
+    const router = this.registry.get('router') as Router;
     const location = world?.data?.位置 ?? '';
     const sha = world?.data?.煞氣 ?? '';
     const yin = world?.data?.陰德 ?? '';
@@ -28,7 +29,27 @@ export default class ShellScene extends ModuleScene {
       .setInteractive({ useHandCursor: true });
 
     mapButton.on('pointerup', () => {
-      this.registry.get('router').push('MapScene');
+      router.push('MapScene');
+    });
+
+    const inventoryButton = this.add
+      .text(width / 2, height / 2 + 60, '物品', {
+        fontSize: '24px',
+        color: '#aaf'
+      })
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true });
+
+    const pickedLabel = this.add
+      .text(16, height - 16, '選擇的物品：無', {
+        fontSize: '16px',
+        color: '#fff'
+      })
+      .setOrigin(0, 1);
+
+    inventoryButton.on('pointerup', async () => {
+      const picked = await router.push<string | null>('InventoryScene');
+      pickedLabel.setText(`選擇的物品：${picked ?? '無'}`);
     });
   }
 }


### PR DESCRIPTION
## Summary
- implement an InventoryScene that lists items from the data repo and returns the chosen id via ModuleScene.done
- wire a new inventory button into the ShellScene that opens the InventoryScene and displays the picked result

## Testing
- npm run build *(fails: existing TypeScript configuration errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d766f05afc832eba994901672b2c6e