### PR TITLE
feat: surface map anchors and dynamic hud

### DIFF
--- a/src/core/AiOrchestrator.ts
+++ b/src/core/AiOrchestrator.ts
@@ -1,7 +1,7 @@
-import { GhostOption, Spirit, WordCard, WorldStateData } from './Types';
+import type { GhostOption, Spirit, WordCard, WorldStateData } from './Types';
 export class AiOrchestrator {
   mode:"local"|"provider"="local";
-  async genGhostOptions(ctx:{ spirit:Spirit; word:WordCard; world:WorldStateData; }): Promise<{options:GhostOption[]; tone:string;}> {
+  async genGhostOptions(_ctx:{ spirit:Spirit; word:WordCard; world:WorldStateData; }): Promise<{options:GhostOption[]; tone:string;}> {
     // 簡易假資料：視為可跑通流程
     const base: GhostOption[] = [
       { text:"讓我替你把名冊找正好嗎？", type:"指認", targets:["e1"], requires:[], effect:"鬆動", hint:"碼頭管理處" },

--- a/src/core/DataRepo.ts
+++ b/src/core/DataRepo.ts
@@ -1,6 +1,8 @@
 export class DataRepo {
   private cache = new Map<string, any>();
-  constructor(private loader:(path:string)=>Promise<any>){
+  private loader:(path:string)=>Promise<any>;
+  constructor(loader:(path:string)=>Promise<any>){
+    this.loader = loader;
   }
   async get<T=any>(name:string): Promise<T> {
     if (this.cache.has(name)) return this.cache.get(name);

--- a/src/core/EventBus.ts
+++ b/src/core/EventBus.ts
@@ -1,0 +1,7 @@
+import Phaser from 'phaser';
+
+class EventBus extends Phaser.Events.EventEmitter {}
+
+export const bus = new EventBus();
+
+export default bus;

--- a/src/core/Router.ts
+++ b/src/core/Router.ts
@@ -3,11 +3,14 @@ export type RouteCtx<TIn=any,TOut=any> = { in?: TIn; resolve: (r:TOut)=>void; re
 
 export class Router {
   private stack: string[] = [];
-  constructor(private game: Phaser.Game) {}
+  private game: Phaser.Game;
+  constructor(game: Phaser.Game) {
+    this.game = game;
+  }
   push<TIn=any,TOut=any>(key: string, input?: TIn): Promise<TOut> {
     return new Promise<TOut>((resolve, reject) => {
       this.stack.push(key);
-      this.game.scene.launch(key, { __route__: { in: input, resolve, reject } as RouteCtx<TIn,TOut> });
+      this.game.scene.run(key, { __route__: { in: input, resolve, reject } as RouteCtx<TIn,TOut> });
     });
   }
   pop() {

--- a/src/core/SaveManager.ts
+++ b/src/core/SaveManager.ts
@@ -1,6 +1,9 @@
 import { WorldState } from './WorldState';
 export class SaveManager {
-  constructor(private world: WorldState){}
+  private world: WorldState;
+  constructor(world: WorldState){
+    this.world = world;
+  }
   private key(slot:number){ return `lm-save-${slot}`; }
   save(slot=0){ localStorage.setItem(this.key(slot), JSON.stringify(this.world.data)); }
   load(slot=0){ const raw = localStorage.getItem(this.key(slot)); if(!raw) throw new Error("no save"); this.world.data = JSON.parse(raw); }

--- a/src/core/WorldState.ts
+++ b/src/core/WorldState.ts
@@ -1,4 +1,4 @@
-import { WorldStateData } from './Types';
+import type { WorldStateData } from './Types';
 export class WorldState {
   data: WorldStateData = {
     位置: "港邊醫館後巷", 煞氣: "濁", 陰德:"低", 同行:[], 物品:[], 字卡:[],

--- a/src/scenes/BootScene.ts
+++ b/src/scenes/BootScene.ts
@@ -4,6 +4,7 @@ import { DataRepo } from '@core/DataRepo';
 import { WorldState } from '@core/WorldState';
 import { SaveManager } from '@core/SaveManager';
 import { AiOrchestrator } from '@core/AiOrchestrator';
+import { bus } from '@core/EventBus';
 
 export default class BootScene extends Phaser.Scene {
   constructor(){ super('BootScene'); }
@@ -20,6 +21,7 @@ export default class BootScene extends Phaser.Scene {
     this.game.registry.set('world', world);
     this.game.registry.set('saver', saver);
     this.game.registry.set('aio', aio);
+    this.game.registry.set('bus', bus);
 
     this.scene.start('TitleScene');
   }

--- a/src/scenes/GhostCommScene.ts
+++ b/src/scenes/GhostCommScene.ts
@@ -1,0 +1,11 @@
+import { ModuleScene } from '@core/Router';
+
+export default class GhostCommScene extends ModuleScene<{ spiritId: string }, { resolvedKnots: string[] }> {
+  constructor() {
+    super('GhostCommScene');
+  }
+
+  create() {
+    this.done?.({ resolvedKnots: [] });
+  }
+}

--- a/src/scenes/HintsScene.ts
+++ b/src/scenes/HintsScene.ts
@@ -1,0 +1,11 @@
+import { ModuleScene } from '@core/Router';
+
+export default class HintsScene extends ModuleScene<void, void> {
+  constructor() {
+    super('HintsScene');
+  }
+
+  create() {
+    this.done?.();
+  }
+}

--- a/src/scenes/MapScene.ts
+++ b/src/scenes/MapScene.ts
@@ -1,4 +1,12 @@
+import Phaser from 'phaser';
 import { ModuleScene } from '@core/Router';
+import { DataRepo } from '@core/DataRepo';
+import { WorldState } from '@core/WorldState';
+
+type AnchorData = {
+  id: string;
+  地點: string;
+};
 
 export default class MapScene extends ModuleScene {
   constructor() {
@@ -8,12 +16,42 @@ export default class MapScene extends ModuleScene {
   create() {
     const { width, height } = this.scale;
 
+    const repo = this.registry.get('repo') as DataRepo | undefined;
+    const world = this.registry.get('world') as WorldState | undefined;
+
+    const currentLocation = world?.data?.位置 ?? '未知';
+    const flagEntries = Object.entries(world?.data?.旗標 ?? {});
+    const flagText = flagEntries.length
+      ? flagEntries.map(([key, value]) => `${key}: ${String(value)}`).join('\n')
+      : '目前沒有旗標資料';
+
     this.add
-      .text(width / 2, height / 2, '這裡會列出可去地點與可啟動劇情', {
-        fontSize: '20px',
+      .text(width / 2, 40, '可去地點', {
+        fontSize: '24px',
         color: '#fff'
       })
-      .setOrigin(0.5);
+      .setOrigin(0.5, 0);
+
+    this.add
+      .text(32, 96, `當前位置：${currentLocation}\n旗標：\n${flagText}`, {
+        fontSize: '18px',
+        color: '#fff'
+      })
+      .setOrigin(0, 0);
+
+    const locationsText = this.add
+      .text(32, 192, '載入可去地點中……', {
+        fontSize: '20px',
+        color: '#fff',
+        lineSpacing: 6
+      })
+      .setOrigin(0, 0);
+
+    if (repo) {
+      void this.populateLocations(repo, locationsText);
+    } else {
+      locationsText.setText('無法取得地點資料（缺少資料倉庫）');
+    }
 
     const saveMessage = this.add
       .text(16, height - 16, '', {
@@ -37,5 +75,20 @@ export default class MapScene extends ModuleScene {
       }
       saveMessage.setText('已存檔');
     });
+  }
+
+  private async populateLocations(repo: DataRepo, label: Phaser.GameObjects.Text) {
+    try {
+      const anchors = await repo.get<AnchorData[]>('anchors');
+      const locationList = anchors.map((anchor) => `・${anchor.地點}`);
+      if (locationList.length === 0) {
+        label.setText('目前沒有可去地點');
+        return;
+      }
+      label.setText(['可前往的地點：', ...locationList].join('\n'));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      label.setText(`讀取地點資料時發生錯誤：${message}`);
+    }
   }
 }

--- a/src/scenes/MediationScene.ts
+++ b/src/scenes/MediationScene.ts
@@ -1,0 +1,11 @@
+import { ModuleScene } from '@core/Router';
+
+export default class MediationScene extends ModuleScene<{ npcId: string }, { npcId: string; stage: string; resolved?: string[] }> {
+  constructor() {
+    super('MediationScene');
+  }
+
+  create() {
+    this.done?.({ npcId: '', stage: '抗拒', resolved: [] });
+  }
+}

--- a/src/scenes/ShellScene.ts
+++ b/src/scenes/ShellScene.ts
@@ -1,4 +1,5 @@
 import { ModuleScene, Router } from '@core/Router';
+import { WorldState } from '@core/WorldState';
 
 export default class ShellScene extends ModuleScene {
   constructor() {
@@ -7,18 +8,26 @@ export default class ShellScene extends ModuleScene {
 
   create() {
     const { width, height } = this.scale;
-    const world = this.registry.get('world');
+    const world = this.registry.get('world') as WorldState | undefined;
     const router = this.registry.get('router') as Router;
-    const location = world?.data?.位置 ?? '';
-    const sha = world?.data?.煞氣 ?? '';
-    const yin = world?.data?.陰德 ?? '';
 
-    this.add
-      .text(16, 16, `位置：${location}\n煞氣：${sha}\n陰德：${yin}`, {
+    const hudText = this.add
+      .text(16, 16, '', {
         fontSize: '16px',
         color: '#fff'
       })
       .setOrigin(0, 0);
+
+    const updateHud = () => {
+      const location = world?.data?.位置 ?? '';
+      const sha = world?.data?.煞氣 ?? '';
+      const yin = world?.data?.陰德 ?? '';
+      hudText.setText(`位置：${location}\n煞氣：${sha}\n陰德：${yin}`);
+    };
+
+    updateHud();
+
+    this.time.addEvent({ delay: 200, loop: true, callback: updateHud });
 
     const mapButton = this.add
       .text(width / 2, height / 2, '開啟地圖', {

--- a/src/scenes/StoryScene.ts
+++ b/src/scenes/StoryScene.ts
@@ -1,0 +1,11 @@
+import { ModuleScene } from '@core/Router';
+
+export default class StoryScene extends ModuleScene<{ storyId: string }, { flagsUpdated: string[] }> {
+  constructor() {
+    super('StoryScene');
+  }
+
+  async create() {
+    this.done?.({ flagsUpdated: [] });
+  }
+}

--- a/src/scenes/WordCardsScene.ts
+++ b/src/scenes/WordCardsScene.ts
@@ -1,0 +1,11 @@
+import { ModuleScene } from '@core/Router';
+
+export default class WordCardsScene extends ModuleScene<void, void> {
+  constructor() {
+    super('WordCardsScene');
+  }
+
+  create() {
+    this.done?.();
+  }
+}


### PR DESCRIPTION
## Summary
- add a Phaser event bus singleton and expose it through the registry
- load anchor data in MapScene to show current world state and available destinations
- refresh the ShellScene HUD text on a timer so it reflects live world changes

## Testing
- npm run build *(fails: pre-existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d76a3d4db4832e9fa9c3551694d829