### PR TITLE
Add interactive story scene and trigger

### DIFF
--- a/assets/data/stories.json
+++ b/assets/data/stories.json
@@ -5,6 +5,7 @@
       {"t":"TEXT","who":"旁白","text":"廳堂微潮，燈影搖。"},
       {"t":"TEXT","who":"亡魂","text":"她不吃塑膠做的飯。"},
       {"t":"CALL_GHOST_COMM","spiritId":"spirit_wang_ayi"},
+      {"t":"CALL_MEDIATION","npcId":"npc_wang_shushu"},
       {"t":"END"}
     ]
   }

--- a/src/scenes/GhostCommScene.ts
+++ b/src/scenes/GhostCommScene.ts
@@ -1,11 +1,355 @@
+import Phaser from 'phaser';
 import { ModuleScene } from '@core/Router';
+import type { DataRepo } from '@core/DataRepo';
+import type { AiOrchestrator } from '@core/AiOrchestrator';
+import type { Spirit, WordCard, GhostOption } from '@core/Types';
+import type { WorldState } from '@core/WorldState';
 
-export default class GhostCommScene extends ModuleScene<{ spiritId: string }, { resolvedKnots: string[] }> {
+interface GhostCommResult {
+  resolvedKnots: string[];
+  miasma: string;
+}
+
+type ObsessionState = '鬆動' | '已解';
+
+export default class GhostCommScene extends ModuleScene<{ spiritId: string }, GhostCommResult> {
+  private repo?: DataRepo;
+  private world?: WorldState;
+  private aio?: AiOrchestrator;
+
+  private spirit?: Spirit;
+  private wordCards: WordCard[] = [];
+
+  private statusText?: Phaser.GameObjects.Text;
+  private optionContainer?: Phaser.GameObjects.Container;
+  private feedbackText?: Phaser.GameObjects.Text;
+
+  private obsessionState = new Map<string, ObsessionState>();
+  private loadingOptions = false;
+
   constructor() {
     super('GhostCommScene');
   }
 
-  create() {
-    this.done?.({ resolvedKnots: [] });
+  async create() {
+    const spiritId = this.route?.in?.spiritId;
+    this.repo = this.registry.get('repo') as DataRepo | undefined;
+    this.world = this.registry.get('world') as WorldState | undefined;
+    this.aio = this.registry.get('aio') as AiOrchestrator | undefined;
+
+    if (!spiritId || !this.repo || !this.world || !this.aio) {
+      this.showErrorAndExit('缺少必要資料，無法進行靈體溝通。');
+      return;
+    }
+
+    try {
+      const [spirits, wordcards] = await Promise.all([
+        this.repo.get<Spirit[]>('spirits'),
+        this.repo.get<WordCard[]>('wordcards')
+      ]);
+
+      this.spirit = spirits.find((sp) => sp.id === spiritId);
+      if (!this.spirit) {
+        this.showErrorAndExit('找不到指定靈體。');
+        return;
+      }
+
+      this.wordCards = wordcards;
+      this.buildLayout();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.showErrorAndExit(`讀取資料時發生錯誤：${message}`);
+    }
+  }
+
+  private buildLayout() {
+    const { width, height } = this.scale;
+
+    this.add
+      .text(32, 32, `與 ${this.spirit?.名 ?? '未知靈體'} 溝通`, {
+        fontSize: '26px',
+        color: '#fff'
+      })
+      .setOrigin(0, 0);
+
+    this.statusText = this.add
+      .text(32, 96, this.getStatusSummary(), {
+        fontSize: '18px',
+        color: '#fff',
+        lineSpacing: 6,
+        wordWrap: { width: width * 0.5 }
+      })
+      .setOrigin(0, 0);
+
+    this.feedbackText = this.add
+      .text(32, height - 96, '', {
+        fontSize: '18px',
+        color: '#aaf',
+        wordWrap: { width: width * 0.5 }
+      })
+      .setOrigin(0, 0);
+
+    const endButton = this.add
+      .text(width / 2, height - 32, '結束溝通', {
+        fontSize: '22px',
+        color: '#aaf'
+      })
+      .setOrigin(0.5, 1)
+      .setInteractive({ useHandCursor: true });
+
+    endButton.on('pointerup', () => {
+      this.finish();
+    });
+
+    this.buildWordCardList(width);
+    this.buildOptionsPanel(width, height);
+  }
+
+  private buildWordCardList(width: number) {
+    const listX = width - 220;
+    const listTop = 80;
+
+    this.add
+      .text(listX, 32, '可用字卡', {
+        fontSize: '22px',
+        color: '#fff'
+      })
+      .setOrigin(0.5, 0);
+
+    const totalRows = Math.max(6, this.wordCards.length);
+    const rowHeight = 48;
+
+    for (let index = 0; index < totalRows; index += 1) {
+      const card = this.wordCards[index];
+      const labelText = card ? card.字 : '（空）';
+      const text = this.add
+        .text(listX, listTop + index * rowHeight, labelText, {
+          fontSize: '20px',
+          color: card ? '#aaf' : '#666'
+        })
+        .setOrigin(0.5, 0)
+        .setInteractive(card ? { useHandCursor: true } : undefined);
+
+      if (card) {
+        text.on('pointerup', () => {
+          this.handleWordCardSelected(card);
+        });
+      }
+    }
+  }
+
+  private buildOptionsPanel(width: number, height: number) {
+    const panelX = width * 0.6;
+    const panelWidth = width * 0.3;
+
+    this.optionContainer = this.add.container(panelX, 140);
+
+    const panelBg = this.add
+      .rectangle(0, 0, panelWidth, height - 220, 0x000000, 0.4)
+      .setOrigin(0, 0);
+    this.optionContainer.add(panelBg);
+
+    const title = this.add
+      .text(panelWidth / 2, 12, '溝通選項', {
+        fontSize: '20px',
+        color: '#fff'
+      })
+      .setOrigin(0.5, 0);
+    this.optionContainer.add(title);
+
+    const hint = this.add
+      .text(panelWidth / 2, 48, '請選擇右側字卡', {
+        fontSize: '16px',
+        color: '#ccc',
+        wordWrap: { width: panelWidth - 24 }
+      })
+      .setOrigin(0.5, 0);
+    hint.setData('type', 'hint');
+    this.optionContainer.add(hint);
+  }
+
+  private async handleWordCardSelected(card: WordCard) {
+    if (!this.aio || !this.spirit || !this.world || this.loadingOptions) {
+      return;
+    }
+    this.loadingOptions = true;
+
+    this.setOptionsText(['載入選項中……']);
+
+    try {
+      const { options } = await this.aio.genGhostOptions({
+        spirit: this.spirit,
+        word: card,
+        world: this.world.data
+      });
+
+      if (!options.length) {
+        this.setOptionsText(['目前沒有可用選項。']);
+      } else {
+        this.populateOptions(options.map((option) => ({ card, option })));
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.setOptionsText([`取得選項失敗：${message}`]);
+    } finally {
+      this.loadingOptions = false;
+    }
+  }
+
+  private populateOptions(entries: { card: WordCard; option: GhostOption }[]) {
+    if (!this.optionContainer) {
+      return;
+    }
+
+    const panelWidth = (this.optionContainer.list[0] as Phaser.GameObjects.Rectangle).width;
+    const optionStartY = 48;
+    const optionSpacing = 48;
+
+    this.optionContainer.removeAll(true);
+
+    const panelBg = this.add
+      .rectangle(0, 0, panelWidth, this.scale.height - 220, 0x000000, 0.4)
+      .setOrigin(0, 0);
+    this.optionContainer.add(panelBg);
+
+    const title = this.add
+      .text(panelWidth / 2, 12, '溝通選項', {
+        fontSize: '20px',
+        color: '#fff'
+      })
+      .setOrigin(0.5, 0);
+    this.optionContainer.add(title);
+
+    entries.forEach(({ option }, idx) => {
+      const display = this.fitOptionText(String(option.text ?? '選項'), 40);
+      const optionText = this.add
+        .text(panelWidth / 2, optionStartY + idx * optionSpacing, display, {
+          fontSize: '18px',
+          color: '#aaf',
+          wordWrap: { width: panelWidth - 24 },
+          align: 'center'
+        })
+        .setOrigin(0.5, 0)
+        .setInteractive({ useHandCursor: true });
+
+      optionText.on('pointerup', () => {
+        this.applyOption(option);
+      });
+
+      this.optionContainer?.add(optionText);
+    });
+  }
+
+  private setOptionsText(lines: string[]) {
+    if (!this.optionContainer) {
+      return;
+    }
+
+    const panelWidth = (this.optionContainer.list[0] as Phaser.GameObjects.Rectangle).width;
+    this.optionContainer.removeAll(true);
+
+    const panelBg = this.add
+      .rectangle(0, 0, panelWidth, this.scale.height - 220, 0x000000, 0.4)
+      .setOrigin(0, 0);
+    this.optionContainer.add(panelBg);
+
+    const title = this.add
+      .text(panelWidth / 2, 12, '溝通選項', {
+        fontSize: '20px',
+        color: '#fff'
+      })
+      .setOrigin(0.5, 0);
+    this.optionContainer.add(title);
+
+    lines.forEach((line, idx) => {
+      const text = this.add
+        .text(panelWidth / 2, 60 + idx * 28, line, {
+          fontSize: '16px',
+          color: '#ccc',
+          wordWrap: { width: panelWidth - 24 },
+          align: 'center'
+        })
+        .setOrigin(0.5, 0);
+      this.optionContainer?.add(text);
+    });
+  }
+
+  private applyOption(option: GhostOption) {
+    if (!this.world) {
+      return;
+    }
+
+    const effect = String(option.effect ?? '');
+    if (effect === '平煞') {
+      const current = this.world.data.煞氣;
+      if (current === '沸') {
+        this.world.data.煞氣 = '濁';
+      } else if (current === '濁') {
+        this.world.data.煞氣 = '清';
+      }
+    } else if (effect === '鬆動' || effect === '解結') {
+      const targets: string[] = Array.isArray(option.targets) ? option.targets : [];
+      targets.forEach((id) => {
+        if (!id) {
+          return;
+        }
+        const nextState: ObsessionState = effect === '解結' ? '已解' : '鬆動';
+        const current = this.obsessionState.get(id);
+        if (current === '已解') {
+          return;
+        }
+        this.obsessionState.set(id, nextState);
+      });
+    }
+
+    const summaryParts: string[] = [];
+    if (effect) {
+      summaryParts.push(`效果：${effect}`);
+    }
+    if (Array.isArray(option.targets) && option.targets.length) {
+      summaryParts.push(`影響執念：${option.targets.join('、')}`);
+    }
+    this.feedbackText?.setText(summaryParts.join('\n'));
+    this.statusText?.setText(this.getStatusSummary());
+  }
+
+  private getStatusSummary() {
+    const miasma = this.world?.data.煞氣 ?? '未知';
+    const obsEntries = Array.from(this.obsessionState.entries());
+    const obsText = obsEntries.length
+      ? obsEntries.map(([id, state]) => `${id}: ${state}`).join('\n')
+      : '尚未撫平任何執念';
+    return `目前煞氣：${miasma}\n執念狀態：\n${obsText}`;
+  }
+
+  private fitOptionText(text: string, maxLength: number) {
+    if (text.length <= maxLength) {
+      return text;
+    }
+    return `${text.slice(0, maxLength - 1)}…`;
+  }
+
+  private finish() {
+    const resolved = Array.from(this.obsessionState.entries())
+      .filter(([, state]) => state === '已解')
+      .map(([id]) => id);
+    const miasma = this.world?.data.煞氣 ?? '未知';
+    this.done({ resolvedKnots: resolved, miasma });
+  }
+
+  private showErrorAndExit(message: string) {
+    const { width, height } = this.scale;
+    this.add
+      .text(width / 2, height / 2, message, {
+        fontSize: '20px',
+        color: '#fff',
+        wordWrap: { width: width - 80 },
+        align: 'center'
+      })
+      .setOrigin(0.5);
+
+    this.time.delayedCall(1200, () => {
+      this.done({ resolvedKnots: [], miasma: this.world?.data.煞氣 ?? '未知' });
+    });
   }
 }

--- a/src/scenes/MapScene.ts
+++ b/src/scenes/MapScene.ts
@@ -1,5 +1,5 @@
 import Phaser from 'phaser';
-import { ModuleScene } from '@core/Router';
+import { ModuleScene, Router } from '@core/Router';
 import { DataRepo } from '@core/DataRepo';
 import { WorldState } from '@core/WorldState';
 
@@ -18,6 +18,7 @@ export default class MapScene extends ModuleScene {
 
     const repo = this.registry.get('repo') as DataRepo | undefined;
     const world = this.registry.get('world') as WorldState | undefined;
+    const router = this.registry.get('router') as Router | undefined;
 
     const currentLocation = world?.data?.位置 ?? '未知';
     const flagEntries = Object.entries(world?.data?.旗標 ?? {});
@@ -60,6 +61,13 @@ export default class MapScene extends ModuleScene {
       })
       .setOrigin(0, 1);
 
+    const storyStatus = this.add
+      .text(width / 2, height - 48, '', {
+        fontSize: '16px',
+        color: '#fff'
+      })
+      .setOrigin(0.5, 1);
+
     const saveButton = this.add
       .text(width - 16, 16, '存檔', {
         fontSize: '18px',
@@ -74,6 +82,32 @@ export default class MapScene extends ModuleScene {
         saver.save(0);
       }
       saveMessage.setText('已存檔');
+    });
+
+    const storyButton = this.add
+      .text(width - 16, 56, '啟動劇情 story_wang_01', {
+        fontSize: '18px',
+        color: '#aaf'
+      })
+      .setOrigin(1, 0)
+      .setInteractive({ useHandCursor: true });
+
+    storyButton.on('pointerup', async () => {
+      if (!router) {
+        storyStatus.setText('無法啟動劇情：缺少路由');
+        return;
+      }
+
+      storyButton.disableInteractive();
+      storyStatus.setText('劇情進行中……');
+      try {
+        await router.push('StoryScene', { storyId: 'story_wang_01' });
+        storyStatus.setText('劇情已完成');
+      } catch (error) {
+        storyStatus.setText('劇情未完成');
+      } finally {
+        storyButton.setInteractive({ useHandCursor: true });
+      }
     });
   }
 

--- a/src/scenes/MapScene.ts
+++ b/src/scenes/MapScene.ts
@@ -2,68 +2,54 @@ import Phaser from 'phaser';
 import { ModuleScene, Router } from '@core/Router';
 import { DataRepo } from '@core/DataRepo';
 import { WorldState } from '@core/WorldState';
+import type { Anchor, StoryNode } from '@core/Types';
 
-type AnchorData = {
-  id: string;
-  地點: string;
-};
+type AnchorEntry = { anchor: Anchor; text: Phaser.GameObjects.Text };
+type StoryEntry = { story?: StoryNode; text: Phaser.GameObjects.Text };
 
 export default class MapScene extends ModuleScene {
+  private world?: WorldState;
+  private router?: Router;
+  private anchors: Anchor[] = [];
+  private stories: StoryNode[] = [];
+  private currentLocation = '未知';
+  private statusLabel?: Phaser.GameObjects.Text;
+  private messageLabel?: Phaser.GameObjects.Text;
+  private messageTimer?: Phaser.Time.TimerEvent;
+  private locationEntries: AnchorEntry[] = [];
+  private storyEntries: StoryEntry[] = [];
+
   constructor() {
     super('MapScene');
   }
 
-  create() {
+  async create() {
     const { width, height } = this.scale;
 
     const repo = this.registry.get('repo') as DataRepo | undefined;
-    const world = this.registry.get('world') as WorldState | undefined;
-    const router = this.registry.get('router') as Router | undefined;
+    this.world = this.registry.get('world') as WorldState | undefined;
+    this.router = this.registry.get('router') as Router | undefined;
 
-    const currentLocation = world?.data?.位置 ?? '未知';
-    const flagEntries = Object.entries(world?.data?.旗標 ?? {});
-    const flagText = flagEntries.length
-      ? flagEntries.map(([key, value]) => `${key}: ${String(value)}`).join('\n')
-      : '目前沒有旗標資料';
+    this.currentLocation = this.world?.data?.位置 ?? '未知';
 
     this.add
-      .text(width / 2, 40, '可去地點', {
-        fontSize: '24px',
+      .text(width / 2, 24, '地圖', {
+        fontSize: '28px',
         color: '#fff'
       })
       .setOrigin(0.5, 0);
 
-    this.add
-      .text(32, 96, `當前位置：${currentLocation}\n旗標：\n${flagText}`, {
+    this.statusLabel = this.add
+      .text(32, 72, '', {
         fontSize: '18px',
-        color: '#fff'
-      })
-      .setOrigin(0, 0);
-
-    const locationsText = this.add
-      .text(32, 192, '載入可去地點中……', {
-        fontSize: '20px',
         color: '#fff',
         lineSpacing: 6
       })
       .setOrigin(0, 0);
 
-    if (repo) {
-      void this.populateLocations(repo, locationsText);
-    } else {
-      locationsText.setText('無法取得地點資料（缺少資料倉庫）');
-    }
-
-    const saveMessage = this.add
-      .text(16, height - 16, '', {
-        fontSize: '16px',
-        color: '#fff'
-      })
-      .setOrigin(0, 1);
-
-    const storyStatus = this.add
-      .text(width / 2, height - 48, '', {
-        fontSize: '16px',
+    this.messageLabel = this.add
+      .text(width / 2, height - 24, '', {
+        fontSize: '18px',
         color: '#fff'
       })
       .setOrigin(0.5, 1);
@@ -81,48 +67,232 @@ export default class MapScene extends ModuleScene {
       if (saver && typeof saver.save === 'function') {
         saver.save(0);
       }
-      saveMessage.setText('已存檔');
+      this.showMessage('已存檔');
     });
 
-    const storyButton = this.add
-      .text(width - 16, 56, '啟動劇情 story_wang_01', {
+    const closeButton = this.add
+      .text(width - 16, height - 24, '返回', {
         fontSize: '18px',
         color: '#aaf'
       })
-      .setOrigin(1, 0)
+      .setOrigin(1, 1)
       .setInteractive({ useHandCursor: true });
 
-    storyButton.on('pointerup', async () => {
-      if (!router) {
-        storyStatus.setText('無法啟動劇情：缺少路由');
-        return;
-      }
+    closeButton.on('pointerup', () => {
+      this.done(undefined);
+    });
 
-      storyButton.disableInteractive();
-      storyStatus.setText('劇情進行中……');
-      try {
-        await router.push('StoryScene', { storyId: 'story_wang_01' });
-        storyStatus.setText('劇情已完成');
-      } catch (error) {
-        storyStatus.setText('劇情未完成');
-      } finally {
-        storyButton.setInteractive({ useHandCursor: true });
+    this.add
+      .text(32, 128, '可去地點', {
+        fontSize: '20px',
+        color: '#fff'
+      })
+      .setOrigin(0, 0);
+
+    this.add
+      .text(width / 2 + 40, 128, '可啟動劇情', {
+        fontSize: '20px',
+        color: '#fff'
+      })
+      .setOrigin(0, 0);
+
+    this.updateStatusLabel();
+
+    if (!repo) {
+      this.showMessage('無法載入地圖資料：缺少資料倉庫');
+      return;
+    }
+
+    try {
+      const [anchors, stories] = await Promise.all([
+        repo.get<Anchor[]>('anchors'),
+        repo.get<StoryNode[]>('stories')
+      ]);
+      this.anchors = anchors;
+      this.stories = stories;
+      this.buildLocationList(32, 168);
+      this.refreshStoryList();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.showMessage(`載入資料失敗：${message}`);
+    }
+  }
+
+  private buildLocationList(x: number, startY: number) {
+    this.locationEntries.forEach(({ text }) => text.destroy());
+    this.locationEntries = [];
+
+    if (this.anchors.length === 0) {
+      const text = this.add
+        .text(x, startY, '目前沒有可去地點', {
+          fontSize: '20px',
+          color: '#fff'
+        })
+        .setOrigin(0, 0);
+      text.disableInteractive();
+      return;
+    }
+
+    this.anchors.forEach((anchor, index) => {
+      const text = this.add
+        .text(x, startY + index * 32, '', {
+          fontSize: '20px',
+          color: '#aaf'
+        })
+        .setOrigin(0, 0)
+        .setInteractive({ useHandCursor: true });
+
+      text.on('pointerup', () => {
+        this.handleLocationClick(anchor);
+      });
+
+      this.locationEntries.push({ anchor, text });
+    });
+
+    this.updateLocationEntries();
+  }
+
+  private updateLocationEntries() {
+    this.locationEntries.forEach(({ anchor, text }) => {
+      const isCurrent = anchor.地點 === this.currentLocation;
+      text.setText(`${isCurrent ? '★' : '・'}${anchor.地點}`);
+      text.setStyle({ color: isCurrent ? '#ff0' : '#aaf' });
+      if (isCurrent) {
+        text.disableInteractive();
+      } else {
+        text.setInteractive({ useHandCursor: true });
       }
     });
   }
 
-  private async populateLocations(repo: DataRepo, label: Phaser.GameObjects.Text) {
-    try {
-      const anchors = await repo.get<AnchorData[]>('anchors');
-      const locationList = anchors.map((anchor) => `・${anchor.地點}`);
-      if (locationList.length === 0) {
-        label.setText('目前沒有可去地點');
-        return;
-      }
-      label.setText(['可前往的地點：', ...locationList].join('\n'));
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      label.setText(`讀取地點資料時發生錯誤：${message}`);
+  private handleLocationClick(anchor: Anchor) {
+    if (!this.world) {
+      this.showMessage('無法更新位置：缺少世界狀態');
+      return;
     }
+
+    const destination = anchor.地點;
+    if (destination === this.currentLocation) {
+      this.showMessage('已在此地');
+      return;
+    }
+
+    if (!this.canEnterLocation(destination)) {
+      this.showMessage('同行者不願進入');
+      return;
+    }
+
+    this.world.data.位置 = destination;
+    this.currentLocation = destination;
+
+    this.showMessage(`已移動至 ${destination}`);
+    this.updateStatusLabel();
+    this.updateLocationEntries();
+    this.refreshStoryList();
+  }
+
+  private refreshStoryList() {
+    this.storyEntries.forEach(({ text }) => text.destroy());
+    this.storyEntries = [];
+
+    const storyStartX = this.scale.width / 2 + 40;
+    const storyStartY = 168;
+
+    const currentAnchor = this.anchors.find((anchor) => anchor.地點 === this.currentLocation);
+    const candidateStories = currentAnchor
+      ? this.stories.filter((story) => story.anchor === currentAnchor.id)
+      : [];
+
+    if (!currentAnchor) {
+      const text = this.add
+        .text(storyStartX, storyStartY, '尚未定位到錨點', {
+          fontSize: '18px',
+          color: '#fff'
+        })
+        .setOrigin(0, 0);
+      this.storyEntries.push({ text });
+      text.disableInteractive();
+      return;
+    }
+
+    if (candidateStories.length === 0) {
+      const text = this.add
+        .text(storyStartX, storyStartY, '目前沒有可啟動的劇情', {
+          fontSize: '18px',
+          color: '#fff'
+        })
+        .setOrigin(0, 0);
+      this.storyEntries.push({ text });
+      text.disableInteractive();
+      return;
+    }
+
+    candidateStories.forEach((story, index) => {
+      const text = this.add
+        .text(storyStartX, storyStartY + index * 32, `・${story.id}`, {
+          fontSize: '20px',
+          color: '#aaf'
+        })
+        .setOrigin(0, 0)
+        .setInteractive({ useHandCursor: true });
+
+      text.on('pointerup', () => {
+        void this.launchStory(story, text);
+      });
+
+      this.storyEntries.push({ story, text });
+    });
+  }
+
+  private async launchStory(story: StoryNode, text: Phaser.GameObjects.Text) {
+    if (!this.router) {
+      this.showMessage('無法啟動劇情：缺少路由');
+      return;
+    }
+
+    text.disableInteractive();
+    text.setStyle({ color: '#ff0' });
+    this.showMessage('劇情進行中……');
+
+    try {
+      await this.router.push('StoryScene', { storyId: story.id });
+      this.showMessage('劇情已完成');
+    } catch (error) {
+      this.showMessage('劇情未完成');
+    } finally {
+      text.setStyle({ color: '#aaf' });
+      text.setInteractive({ useHandCursor: true });
+    }
+  }
+
+  private updateStatusLabel() {
+    if (!this.statusLabel) {
+      return;
+    }
+    const flagEntries = Object.entries(this.world?.data?.旗標 ?? {});
+    const flagText = flagEntries.length
+      ? flagEntries.map(([key, value]) => `${key}: ${String(value)}`).join('\n')
+      : '目前沒有旗標資料';
+    this.statusLabel.setText(`當前位置：${this.currentLocation}\n旗標：\n${flagText}`);
+  }
+
+  private showMessage(message: string) {
+    if (!this.messageLabel) {
+      return;
+    }
+    this.messageLabel.setText(message);
+    if (this.messageTimer) {
+      this.messageTimer.remove(false);
+    }
+    this.messageTimer = this.time.delayedCall(2000, () => {
+      if (this.messageLabel) {
+        this.messageLabel.setText('');
+      }
+    });
+  }
+
+  private canEnterLocation(locationName: string): boolean {
+    // 先用假條件：只有地點名稱包含「廳堂」時視為同行者願意進入。
+    return locationName.includes('廳堂');
   }
 }

--- a/src/scenes/MediationScene.ts
+++ b/src/scenes/MediationScene.ts
@@ -1,11 +1,297 @@
+import Phaser from 'phaser';
 import { ModuleScene } from '@core/Router';
+import type { DataRepo } from '@core/DataRepo';
+import type { NPC } from '@core/Types';
 
-export default class MediationScene extends ModuleScene<{ npcId: string }, { npcId: string; stage: string; resolved?: string[] }> {
+type Stage = '抗拒' | '猶豫' | '願試' | '承諾';
+
+type MediationResult = { npcId: string; stage: Stage; resolved: string[] };
+
+export default class MediationScene extends ModuleScene<{ npcId: string }, MediationResult> {
+  private repo?: DataRepo;
+  private npc?: NPC;
+
+  private stageFlow: Stage[] = ['抗拒', '猶豫', '願試', '承諾'];
+  private currentStage: Stage = '抗拒';
+
+  private stageText?: Phaser.GameObjects.Text;
+  private inputBox?: Phaser.GameObjects.Rectangle;
+  private inputText?: Phaser.GameObjects.Text;
+  private responseText?: Phaser.GameObjects.Text;
+
+  private typing = false;
+  private inputValue = '';
+
+  private readonly negativeKeywords = ['笨', '小氣', '吝嗇', '討厭'];
+  private readonly actionKeywords = ['今晚', '明天', '買', '一起', '準備', '安排', '試試'];
+  private readonly trustKeywords = ['不讓外人知道', '給你面子', '保密', '替你擋'];
+
   constructor() {
     super('MediationScene');
   }
 
-  create() {
-    this.done?.({ npcId: '', stage: '抗拒', resolved: [] });
+  async create() {
+    const npcId = this.route?.in?.npcId;
+    this.repo = this.registry.get('repo') as DataRepo | undefined;
+
+    if (!npcId || !this.repo) {
+      this.showErrorAndExit('缺少必要資料，無法進行調解。', npcId ?? '');
+      return;
+    }
+
+    try {
+      const npcs = await this.repo.get<NPC[]>('npcs');
+      this.npc = npcs.find((entry) => entry.id === npcId);
+      if (!this.npc) {
+        this.showErrorAndExit('找不到指定 NPC。', npcId);
+        return;
+      }
+
+      if (Array.isArray(this.npc.轉折階段) && this.npc.轉折階段.length) {
+        const filtered = this.npc.轉折階段.filter((stage): stage is Stage =>
+          stage === '抗拒' || stage === '猶豫' || stage === '願試' || stage === '承諾'
+        );
+        if (filtered.length) {
+          this.stageFlow = filtered;
+        }
+      }
+      this.currentStage = this.stageFlow[0] ?? '抗拒';
+
+      this.buildLayout();
+      this.registerKeyboard();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.showErrorAndExit(`讀取資料時發生錯誤：${message}`, npcId);
+    }
+  }
+
+  private buildLayout() {
+    const { width, height } = this.scale;
+    const npcName = this.npc?.稱呼 ?? '對方';
+
+    this.add
+      .text(width / 2, 48, `協調 ${npcName}`, {
+        fontSize: '28px',
+        color: '#fff'
+      })
+      .setOrigin(0.5, 0);
+
+    this.stageText = this.add
+      .text(32, 32, '', {
+        fontSize: '20px',
+        color: '#fff'
+      })
+      .setOrigin(0, 0);
+    this.updateStageText();
+
+    this.add
+      .text(width / 2, height / 2 - 80, '請輸入說服的話語', {
+        fontSize: '20px',
+        color: '#ccc'
+      })
+      .setOrigin(0.5, 0.5);
+
+    this.inputBox = this.add
+      .rectangle(width / 2, height / 2, width * 0.5, 64, 0xffffff, 0.08)
+      .setStrokeStyle(2, 0xaaddff, 0.6)
+      .setOrigin(0.5, 0.5)
+      .setInteractive({ useHandCursor: true });
+
+    this.inputBox.on('pointerup', () => {
+      this.typing = true;
+      this.updateInputFocus();
+    });
+
+    this.inputText = this.add
+      .text(width / 2, height / 2, '（點此輸入）', {
+        fontSize: '20px',
+        color: '#fff',
+        wordWrap: { width: width * 0.45 }
+      })
+      .setOrigin(0.5, 0.5);
+
+    const sendButton = this.add
+      .text(width / 2 + width * 0.25 - 60, height / 2 + 90, '送出', {
+        fontSize: '22px',
+        color: '#aaf'
+      })
+      .setOrigin(0.5, 0.5)
+      .setInteractive({ useHandCursor: true });
+
+    sendButton.on('pointerup', () => {
+      this.submitInput();
+    });
+
+    const endButton = this.add
+      .text(width / 2, height - 40, '結束', {
+        fontSize: '22px',
+        color: '#aaf'
+      })
+      .setOrigin(0.5, 1)
+      .setInteractive({ useHandCursor: true });
+
+    endButton.on('pointerup', () => {
+      this.finish();
+    });
+
+    this.responseText = this.add
+      .text(width / 2, height / 2 + 160, '', {
+        fontSize: '20px',
+        color: '#aaf',
+        wordWrap: { width: width * 0.6 },
+        align: 'center'
+      })
+      .setOrigin(0.5, 0);
+
+    this.input.on('pointerup', (_pointer: Phaser.Input.Pointer, currentlyOver: Phaser.GameObjects.GameObject[]) => {
+      if (!currentlyOver.includes(this.inputBox as Phaser.GameObjects.GameObject)) {
+        this.typing = false;
+        this.updateInputFocus();
+      }
+    });
+  }
+
+  private registerKeyboard() {
+    const keyboard = this.input.keyboard;
+    if (!keyboard) {
+      return;
+    }
+
+    keyboard.on('keydown', this.handleKeyInput, this);
+
+    this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
+      keyboard.off('keydown', this.handleKeyInput, this);
+    });
+  }
+
+  private handleKeyInput(event: KeyboardEvent) {
+    if (!this.typing) {
+      return;
+    }
+
+    if (event.key === 'Backspace') {
+      event.preventDefault();
+      this.inputValue = this.inputValue.slice(0, -1);
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      this.submitInput();
+      return;
+    } else if (event.key.length === 1) {
+      if (this.inputValue.length < 80) {
+        this.inputValue += event.key;
+      }
+    }
+
+    this.updateInputText();
+  }
+
+  private updateInputText() {
+    if (!this.inputText) {
+      return;
+    }
+    const content = this.inputValue.trim().length ? this.inputValue : '（點此輸入）';
+    this.inputText.setText(content);
+  }
+
+  private updateInputFocus() {
+    if (!this.inputBox) {
+      return;
+    }
+    const alpha = this.typing ? 1 : 0.6;
+    this.inputBox.setStrokeStyle(2, 0xaaddff, alpha);
+    this.updateInputText();
+  }
+
+  private submitInput() {
+    const message = this.inputValue.trim();
+    if (!message) {
+      this.showResponse('先說點什麼吧。');
+      return;
+    }
+
+    const delta = this.evaluateMessage(message);
+    const applied = this.applyStageDelta(delta);
+    this.showResponse(this.composeReply(applied));
+
+    this.inputValue = '';
+    this.typing = false;
+    this.updateStageText();
+    this.updateInputFocus();
+  }
+
+  private evaluateMessage(message: string) {
+    const normalized = message.replace(/\s+/g, '');
+    if (this.negativeKeywords.some((word) => normalized.includes(word))) {
+      return 0;
+    }
+
+    const hasAction = this.actionKeywords.some((word) => message.includes(word));
+    if (!hasAction) {
+      return 0;
+    }
+
+    let delta = 1;
+    if (this.trustKeywords.some((word) => message.includes(word))) {
+      delta += 1;
+    }
+    return delta;
+  }
+
+  private applyStageDelta(delta: number) {
+    if (delta <= 0) {
+      return 0;
+    }
+    const currentIndex = this.stageFlow.indexOf(this.currentStage);
+    const newIndex = Math.min(this.stageFlow.length - 1, currentIndex + delta);
+    const applied = Math.max(0, newIndex - currentIndex);
+    this.currentStage = this.stageFlow[newIndex] ?? this.currentStage;
+    return applied;
+  }
+
+  private composeReply(applied: number) {
+    if (applied === 0) {
+      return '他皺眉：「別這樣說。」';
+    }
+
+    switch (this.currentStage) {
+      case '猶豫':
+        return '他語氣放軟：「好吧，我再想想。」';
+      case '願試':
+        return '他點頭：「嗯，我可以試試看。」';
+      case '承諾':
+        return '他鄭重地說：「好，我會做到。」';
+      default:
+        return '他神色依舊，沒有太大反應。';
+    }
+  }
+
+  private showResponse(text: string) {
+    this.responseText?.setText(text);
+  }
+
+  private updateStageText() {
+    this.stageText?.setText(`目前階段：${this.currentStage}`);
+  }
+
+  private finish() {
+    const resolved = this.currentStage === '承諾' ? ['e_offering', 'e_apology'] : [];
+    const npcId = this.npc?.id ?? this.route?.in?.npcId ?? '';
+    this.done({ npcId, stage: this.currentStage, resolved });
+  }
+
+  private showErrorAndExit(message: string, npcId: string) {
+    const { width, height } = this.scale;
+    this.add
+      .text(width / 2, height / 2, message, {
+        fontSize: '20px',
+        color: '#fff',
+        wordWrap: { width: width - 120 },
+        align: 'center'
+      })
+      .setOrigin(0.5, 0.5);
+
+    this.time.delayedCall(1200, () => {
+      this.done({ npcId, stage: this.currentStage, resolved: [] });
+    });
   }
 }

--- a/src/scenes/StoryScene.ts
+++ b/src/scenes/StoryScene.ts
@@ -1,11 +1,201 @@
+import Phaser from 'phaser';
 import { ModuleScene } from '@core/Router';
+import type { DataRepo } from '@core/DataRepo';
+import type { WorldState } from '@core/WorldState';
+
+type StoryTextStep = { t: 'TEXT'; who?: string; text: string };
+type StoryGiveItemStep = { t: 'GIVE_ITEM'; itemId: string; message?: string };
+type StoryUpdateFlagStep = { t: 'UPDATE_FLAG'; flag: string; value: unknown };
+type StoryEndStep = { t: 'END' };
+type StoryStep =
+  | StoryTextStep
+  | StoryGiveItemStep
+  | StoryUpdateFlagStep
+  | StoryEndStep
+  | { t: string; [key: string]: unknown };
+
+type StoryNode = {
+  id: string;
+  steps: StoryStep[];
+};
 
 export default class StoryScene extends ModuleScene<{ storyId: string }, { flagsUpdated: string[] }> {
+  private steps: StoryStep[] = [];
+  private stepIndex = 0;
+  private awaitingInput = false;
+  private finished = false;
+  private flagsUpdated = new Set<string>();
+  private world?: WorldState;
+  private textBox!: Phaser.GameObjects.Text;
+  private promptText!: Phaser.GameObjects.Text;
+
   constructor() {
     super('StoryScene');
   }
 
   async create() {
-    this.done?.({ flagsUpdated: [] });
+    const { width, height } = this.scale;
+
+    this.textBox = this.add
+      .text(width / 2, height / 2 - 40, '', {
+        fontSize: '24px',
+        color: '#fff',
+        align: 'center',
+        wordWrap: { width: width - 120 }
+      })
+      .setOrigin(0.5);
+
+    this.promptText = this.add
+      .text(width / 2, height / 2 + 60, '點擊繼續', {
+        fontSize: '18px',
+        color: '#ccc'
+      })
+      .setOrigin(0.5)
+      .setVisible(false);
+
+    this.input.on('pointerup', () => {
+      if (this.awaitingInput) {
+        this.awaitingInput = false;
+        this.promptText.setVisible(false);
+        this.advance();
+      }
+    });
+
+    const storyId = this.route?.in?.storyId;
+    if (!storyId) {
+      this.showErrorAndExit('未指定劇情，無法播放。');
+      return;
+    }
+
+    const repo = this.registry.get('repo') as DataRepo | undefined;
+    this.world = this.registry.get('world') as WorldState | undefined;
+
+    if (!repo) {
+      this.showErrorAndExit('缺少資料倉庫，無法讀取劇情。');
+      return;
+    }
+
+    try {
+      const stories = await repo.get<StoryNode[]>('stories');
+      const story = stories.find((node) => node.id === storyId);
+      if (!story) {
+        this.showErrorAndExit('找不到指定的劇情節點。');
+        return;
+      }
+
+      this.steps = story.steps ?? [];
+      if (!this.steps.length) {
+        this.finishStory();
+        return;
+      }
+
+      this.advance();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.showErrorAndExit(`讀取劇情時發生錯誤：${message}`);
+    }
+  }
+
+  private advance() {
+    while (this.stepIndex < this.steps.length) {
+      const step = this.steps[this.stepIndex++];
+      switch (step.t) {
+        case 'TEXT':
+          if (this.isTextStep(step)) {
+            this.displayText(step);
+            return;
+          }
+          break;
+        case 'GIVE_ITEM':
+          if (this.isGiveItemStep(step)) {
+            this.handleGiveItem(step);
+          }
+          break;
+        case 'UPDATE_FLAG':
+          if (this.isUpdateFlagStep(step)) {
+            this.handleUpdateFlag(step);
+          }
+          break;
+        case 'END':
+          this.finishStory();
+          return;
+        default:
+          // 未支援的指令直接略過
+          break;
+      }
+    }
+
+    this.finishStory();
+  }
+
+  private displayText(step: StoryTextStep) {
+    const lines = step.who ? `${step.who}：${step.text}` : step.text;
+    this.textBox.setText(lines);
+    this.promptText.setVisible(true);
+    this.awaitingInput = true;
+  }
+
+  private handleGiveItem(step: StoryGiveItemStep) {
+    const itemId = step.itemId;
+    if (itemId && this.world) {
+      this.world.grantItem(itemId);
+    }
+
+    const toastMessage = step.message ?? (itemId ? `獲得物品：${itemId}` : '獲得物品');
+    this.showToast(toastMessage);
+  }
+
+  private handleUpdateFlag(step: StoryUpdateFlagStep) {
+    if (!this.world || !step.flag) {
+      return;
+    }
+    this.world.setFlag(step.flag, step.value);
+    this.flagsUpdated.add(step.flag);
+  }
+
+  private isTextStep(step: StoryStep): step is StoryTextStep {
+    return step.t === 'TEXT' && typeof (step as Partial<StoryTextStep>).text === 'string';
+  }
+
+  private isGiveItemStep(step: StoryStep): step is StoryGiveItemStep {
+    return step.t === 'GIVE_ITEM' && typeof (step as Partial<StoryGiveItemStep>).itemId === 'string';
+  }
+
+  private isUpdateFlagStep(step: StoryStep): step is StoryUpdateFlagStep {
+    return step.t === 'UPDATE_FLAG' && typeof (step as Partial<StoryUpdateFlagStep>).flag === 'string';
+  }
+
+  private showToast(message: string) {
+    const { width, height } = this.scale;
+    const toast = this.add
+      .text(width - 16, height - 16, message, {
+        fontSize: '16px',
+        color: '#fff',
+        backgroundColor: '#000000aa',
+        padding: { x: 12, y: 6 }
+      })
+      .setOrigin(1, 1);
+
+    this.time.delayedCall(2000, () => {
+      toast.destroy();
+    });
+  }
+
+  private showErrorAndExit(message: string) {
+    this.textBox.setText(message);
+    this.promptText.setText('點擊返回').setVisible(true);
+    const handler = () => {
+      this.input.off('pointerup', handler);
+      this.finishStory();
+    };
+    this.input.once('pointerup', handler);
+  }
+
+  private finishStory() {
+    if (this.finished) {
+      return;
+    }
+    this.finished = true;
+    this.done({ flagsUpdated: Array.from(this.flagsUpdated) });
   }
 }


### PR DESCRIPTION
## Summary
- implement StoryScene that loads story data, handles supported step types, and returns updated flags
- show toasts for granted items and guard unsupported instructions during playback
- add a MapScene entry point for story_wang_01 with completion feedback

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d76ec2b720832ebab51084d091612e