### PR TITLE
Add word card and hint scenes to shell

### DIFF
--- a/src/scenes/HintsScene.ts
+++ b/src/scenes/HintsScene.ts
@@ -1,11 +1,61 @@
 import { ModuleScene } from '@core/Router';
+import type { DataRepo } from '@core/DataRepo';
+import { WorldState } from '@core/WorldState';
+
+type StringsData = {
+  ui?: {
+    hints?: string;
+  };
+};
 
 export default class HintsScene extends ModuleScene<void, void> {
   constructor() {
     super('HintsScene');
   }
 
-  create() {
-    this.done?.();
+  async create() {
+    const repo = this.registry.get('repo') as DataRepo | undefined;
+    const world = this.registry.get('world') as WorldState | undefined;
+    const { width, height } = this.scale;
+
+    let title = '提示';
+
+    if (repo) {
+      try {
+        const strings = await repo.get<StringsData>('strings');
+        title = strings?.ui?.hints ?? title;
+      } catch (error) {
+        // ignore load errors and keep default title
+      }
+    }
+
+    this.add.text(width / 2, 48, title, { fontSize: '28px', color: '#fff' }).setOrigin(0.5);
+
+    const flags = world?.data?.旗標 ?? {};
+    const entries = Object.entries(flags);
+
+    const directionsText = entries.length
+      ? entries
+          .map(([key, value]) => `• ${key}：${typeof value === 'string' ? value : JSON.stringify(value)}`)
+          .join('\n')
+      : '目前沒有可採取的方向。';
+
+    this.add
+      .text(width / 2, height / 2, directionsText, {
+        fontSize: '20px',
+        color: '#fff',
+        align: 'center',
+        wordWrap: { width: width - 80 }
+      })
+      .setOrigin(0.5);
+
+    const closeButton = this.add
+      .text(width / 2, height - 80, '關閉', { fontSize: '22px', color: '#aaf' })
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true });
+
+    closeButton.on('pointerup', () => {
+      this.done(undefined as void);
+    });
   }
 }

--- a/src/scenes/ShellScene.ts
+++ b/src/scenes/ShellScene.ts
@@ -60,5 +60,29 @@ export default class ShellScene extends ModuleScene {
       const picked = await router.push<string | null>('InventoryScene');
       pickedLabel.setText(`選擇的物品：${picked ?? '無'}`);
     });
+
+    const wordCardsButton = this.add
+      .text(width / 2, height / 2 + 120, '字卡', {
+        fontSize: '24px',
+        color: '#aaf'
+      })
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true });
+
+    wordCardsButton.on('pointerup', () => {
+      router.push('WordCardsScene');
+    });
+
+    const hintsButton = this.add
+      .text(width / 2, height / 2 + 180, '提示', {
+        fontSize: '24px',
+        color: '#aaf'
+      })
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true });
+
+    hintsButton.on('pointerup', () => {
+      router.push('HintsScene');
+    });
   }
 }

--- a/src/scenes/WordCardsScene.ts
+++ b/src/scenes/WordCardsScene.ts
@@ -1,11 +1,81 @@
 import { ModuleScene } from '@core/Router';
+import type { DataRepo } from '@core/DataRepo';
+import type { WordCard } from '@core/Types';
 
 export default class WordCardsScene extends ModuleScene<void, void> {
   constructor() {
     super('WordCardsScene');
   }
 
-  create() {
-    this.done?.();
+  async create() {
+    const repo = this.registry.get('repo') as DataRepo | undefined;
+    const { width, height } = this.scale;
+
+    this.add.text(width / 2, 48, '字卡', { fontSize: '28px', color: '#fff' }).setOrigin(0.5);
+
+    const noteLabel = this.add
+      .text(width / 2, height - 180, '點選字卡以檢視備註', {
+        fontSize: '18px',
+        color: '#fff',
+        align: 'center',
+        wordWrap: { width: width - 80 }
+      })
+      .setOrigin(0.5, 0);
+
+    const closeButton = this.add
+      .text(width / 2, height - 80, '關閉', { fontSize: '22px', color: '#aaf' })
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true });
+
+    closeButton.on('pointerup', () => {
+      this.done(undefined as void);
+    });
+
+    if (!repo) {
+      noteLabel.setText('資料庫不可用');
+      closeButton.setStyle({ color: '#faa' });
+      return;
+    }
+
+    const cards = await repo.get<WordCard[]>('wordcards');
+    const entries: { id: string; text: Phaser.GameObjects.Text; card: WordCard }[] = [];
+    let selectedId: string | null = null;
+
+    const updateSelection = () => {
+      entries.forEach(({ id, text, card }) => {
+        const tags = (card['標籤'] ?? []).join('、');
+        const displayLabel = tags ? `${card['字']}（${tags}）` : card['字'];
+        text.setText(displayLabel);
+        text.setStyle({ color: id === selectedId ? '#ff0' : '#aaf' });
+        if (id === selectedId) {
+          const note = card['備註']?.trim();
+          const noteText = note && note.length > 0 ? note : '尚無備註。';
+          const title = tags ? `${card['字']}（${tags}）` : card['字'];
+          noteLabel.setText(`${title}\n${noteText}`.trim());
+        }
+      });
+
+      if (!selectedId) {
+        noteLabel.setText('點選字卡以檢視備註');
+      }
+    };
+
+    cards.forEach((card, index) => {
+      const tags = (card['標籤'] ?? []).join('、');
+      const label = tags ? `${card['字']}（${tags}）` : card['字'];
+      const text = this.add
+        .text(width / 2, 120 + index * 36, label, { fontSize: '20px', color: '#aaf' })
+        .setOrigin(0.5)
+        .setInteractive({ useHandCursor: true });
+
+      text.on('pointerup', () => {
+        selectedId = card.id;
+        updateSelection();
+      });
+
+      entries.push({ id: card.id, text, card });
+    });
+
+    updateSelection();
   }
 }


### PR DESCRIPTION
## Summary
- implement a word card scene that loads cards from the repo and shows notes on selection
- implement a hints scene that surfaces current world flags with a close action
- expose the word card and hints scenes through new buttons in the shell

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d77715490c832eada326da2489547f