### PR TITLE
Mark map stories as completed once finished

### DIFF
--- a/src/scenes/MapScene.ts
+++ b/src/scenes/MapScene.ts
@@ -242,15 +242,25 @@ export default class MapScene extends ModuleScene {
     }
 
     candidateStories.forEach((story, index) => {
+      const finished = this.isStoryFinished(story);
       const text = this.add
-        .text(storyStartX, storyStartY + index * 32, `・${story.id}`, {
-          fontSize: '20px',
-          color: '#aaf'
-        })
+        .text(
+          storyStartX,
+          storyStartY + index * 32,
+          `・${story.id}${finished ? '（已完成）' : ''}`,
+          {
+            fontSize: '20px',
+            color: finished ? '#777' : '#aaf'
+          }
+        )
         .setOrigin(0, 0)
-        .setInteractive({ useHandCursor: true });
+        .setInteractive({ useHandCursor: !finished });
 
       text.on('pointerup', () => {
+        if (this.isStoryFinished(story)) {
+          this.showMessage('劇情已完成');
+          return;
+        }
         void this.launchStory(story, text);
       });
 
@@ -261,6 +271,12 @@ export default class MapScene extends ModuleScene {
   private async launchStory(story: StoryNode, text: Phaser.GameObjects.Text) {
     if (!this.router) {
       this.showMessage('無法啟動劇情：缺少路由');
+      return;
+    }
+
+    if (this.isStoryFinished(story)) {
+      this.showMessage('劇情已完成');
+      this.refreshStoryList();
       return;
     }
 
@@ -331,5 +347,11 @@ export default class MapScene extends ModuleScene {
     const clearedSpirits = this.world?.data?.已安息靈 ?? [];
     const serviceSpirit = anchor.服務靈;
     return !!serviceSpirit && clearedSpirits.includes(serviceSpirit);
+  }
+
+  private isStoryFinished(story: StoryNode): boolean {
+    const flagKey = `story:${story.id}`;
+    const flags = this.world?.data?.旗標 ?? {};
+    return Boolean(flags[flagKey]);
   }
 }

--- a/src/scenes/StoryScene.ts
+++ b/src/scenes/StoryScene.ts
@@ -39,6 +39,8 @@ export default class StoryScene extends ModuleScene<{ storyId: string }, { flags
   private textBox!: Phaser.GameObjects.Text;
   private promptText!: Phaser.GameObjects.Text;
   private skipNextMediationStep = false;
+  private storyId?: string;
+  private storyLoaded = false;
 
   constructor() {
     super('StoryScene');
@@ -78,6 +80,8 @@ export default class StoryScene extends ModuleScene<{ storyId: string }, { flags
       return;
     }
 
+    this.storyId = storyId;
+
     this.repo = this.registry.get('repo') as DataRepo | undefined;
     this.world = this.registry.get('world') as WorldState | undefined;
     this.router = this.registry.get('router') as Router | undefined;
@@ -96,6 +100,7 @@ export default class StoryScene extends ModuleScene<{ storyId: string }, { flags
       }
 
       this.steps = story.steps ?? [];
+      this.storyLoaded = true;
       if (!this.steps.length) {
         this.finishStory();
         return;
@@ -319,6 +324,12 @@ export default class StoryScene extends ModuleScene<{ storyId: string }, { flags
       return;
     }
     this.finished = true;
+    if (this.storyLoaded && this.storyId && this.world) {
+      const flagKey = `story:${this.storyId}`;
+      this.world.setFlag(flagKey, true);
+      this.flagsUpdated.add(flagKey);
+    }
+
     this.done({ flagsUpdated: Array.from(this.flagsUpdated) });
   }
 }


### PR DESCRIPTION
## Summary
- record a completion flag in world state when a story finishes
- prevent relaunching finished stories from the map and show a completed indicator in the list

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7a5e553c8832e940dffa90260d7f2