### PR TITLE
Add GhostDirector to manage spirit states

### DIFF
--- a/src/core/GhostDirector.ts
+++ b/src/core/GhostDirector.ts
@@ -1,0 +1,78 @@
+import type { WorldState } from './WorldState';
+
+export type GhostState =
+  | '未現身'
+  | '現身'
+  | '失我'
+  | '溝通中'
+  | '拒談'
+  | '沉默'
+  | '安息'
+  | '回聲';
+
+export class GhostDirector {
+  private static readonly STATE_FLAG_PREFIX = 'spirit.';
+  private static readonly STATE_FLAG_SUFFIX = '.state';
+
+  static getStateFlagKey(spiritId: string): string {
+    return `${this.STATE_FLAG_PREFIX}${spiritId}${this.STATE_FLAG_SUFFIX}`;
+  }
+
+  static getState(spiritId: string, world: WorldState | undefined): GhostState {
+    if (!spiritId) {
+      return '未現身';
+    }
+
+    const data = world?.data;
+    if (!data) {
+      return '未現身';
+    }
+
+    if (data.已安息靈?.includes(spiritId)) {
+      return '安息';
+    }
+
+    const flagKey = this.getStateFlagKey(spiritId);
+    const rawState = data.旗標?.[flagKey];
+    if (typeof rawState === 'string' && this.isGhostState(rawState)) {
+      return rawState;
+    }
+
+    return '未現身';
+  }
+
+  static setState(spiritId: string, state: GhostState, world: WorldState | undefined): void {
+    if (!world || !spiritId) {
+      return;
+    }
+    const flagKey = this.getStateFlagKey(spiritId);
+    world.setFlag(flagKey, state);
+  }
+
+  static markResolved(spiritId: string, world: WorldState | undefined): void {
+    if (!world || !spiritId) {
+      return;
+    }
+    const data = world.data;
+    if (!data.已安息靈.includes(spiritId)) {
+      data.已安息靈.push(spiritId);
+    }
+    this.setState(spiritId, '安息', world);
+  }
+
+  private static isGhostState(value: string): value is GhostState {
+    switch (value) {
+      case '未現身':
+      case '現身':
+      case '失我':
+      case '溝通中':
+      case '拒談':
+      case '沉默':
+      case '安息':
+      case '回聲':
+        return true;
+      default:
+        return false;
+    }
+  }
+}

--- a/src/scenes/MapScene.ts
+++ b/src/scenes/MapScene.ts
@@ -4,6 +4,7 @@ import { DataRepo } from '@core/DataRepo';
 import { WorldState } from '@core/WorldState';
 import { SpawnDirector, type DirectedAnchor } from '@core/SpawnDirector';
 import type { Anchor, NPC, Spirit, StoryNode } from '@core/Types';
+import { GhostDirector } from '@core/GhostDirector';
 
 type AnchorEntry = { anchor?: DirectedAnchor; text: Phaser.GameObjects.Text };
 type StoryEntry = { story?: StoryNode; text: Phaser.GameObjects.Text };
@@ -139,11 +140,12 @@ export default class MapScene extends ModuleScene {
 
     this.accessibleAnchors.forEach((anchor, index) => {
       const isCurrent = anchor.地點 === this.currentLocation;
-      const resolved = Boolean(anchor.meta?.resolved);
-      const label = `${anchor.地點}${resolved ? '（已送行）' : ''}`;
-      const color = resolved ? '#777' : isCurrent ? '#ff0' : '#aaf';
+      const ghostState = GhostDirector.getState(anchor.服務靈, this.world);
+      const resolved = ghostState === '安息' || Boolean(anchor.meta?.resolved);
+      const displayText = resolved ? '　' : `${isCurrent ? '★' : '・'}${anchor.地點}`;
+      const color = resolved ? '#444' : isCurrent ? '#ff0' : '#aaf';
       const text = this.add
-        .text(x, startY + index * 32, `${isCurrent ? '★' : '・'}${label}`, {
+        .text(x, startY + index * 32, displayText, {
           fontSize: '20px',
           color
         })
@@ -346,7 +348,7 @@ export default class MapScene extends ModuleScene {
     return this.companionNames.get(id) ?? id;
   }
 
-  private canEnterLocation(locationName: string): boolean {
+  private canEnterLocation(_locationName: string): boolean {
     // 先用假條件：只有地點名稱包含「廳堂」時視為同行者願意進入。
     //return locationName.includes('廳堂');
     return true;

--- a/src/scenes/StoryScene.ts
+++ b/src/scenes/StoryScene.ts
@@ -3,6 +3,7 @@ import { ModuleScene } from '@core/Router';
 import type { DataRepo } from '@core/DataRepo';
 import type { WorldState } from '@core/WorldState';
 import type { Router } from '@core/Router';
+import { GhostDirector } from '@core/GhostDirector';
 
 type StoryTextStep = { t: 'TEXT'; who?: string; text: string };
 type StoryGiveItemStep = { t: 'GIVE_ITEM'; itemId: string; message?: string };
@@ -135,6 +136,11 @@ export default class StoryScene extends ModuleScene<{ storyId: string }, { flags
           break;
         case 'CALL_GHOST_COMM':
           if (this.isCallGhostCommStep(step)) {
+            const state = GhostDirector.getState(step.spiritId, this.world);
+            if (state === '安息' || state === '回聲') {
+              this.showToast(state === '安息' ? '靈體已安息，不再呼喚。' : '此處僅餘回聲。');
+              continue;
+            }
             this.handleCallGhostComm(step);
             return;
           }
@@ -264,11 +270,8 @@ export default class StoryScene extends ModuleScene<{ storyId: string }, { flags
     const hasOfferingOrApology = resolved.includes('e_offering') || resolved.includes('e_apology');
     if (hasOfferingOrApology && world) {
       this.showToast('供桌將擺上熱飯');
-      world.setFlag('已安息: spirit_wang_ayi', true);
-      this.flagsUpdated.add('已安息: spirit_wang_ayi');
-      if (!world.data.已安息靈.includes('spirit_wang_ayi')) {
-        world.data.已安息靈.push('spirit_wang_ayi');
-      }
+      GhostDirector.markResolved('spirit_wang_ayi', world);
+      this.flagsUpdated.add(GhostDirector.getStateFlagKey('spirit_wang_ayi'));
     }
   }
 


### PR DESCRIPTION
## Summary
- add a GhostDirector utility to centralize ghost state tracking and resolution
- skip CALL_GHOST_COMM steps when a spirit is already at rest or only an echo remains
- hide resolved anchors on the map and mark spirits as settled through the director

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7ebb26708832eb4ff6d84aec5e9fc