### PR TITLE
Add interactive dialogue UI and miasma indicator overlays

### DIFF
--- a/docs/security-and-platform.md
+++ b/docs/security-and-platform.md
@@ -1,0 +1,5 @@
+# Security and Platform Notes
+
+- **Web Demo**：僅提供本機模板推論，不接受或儲存任何 API Key。
+- **Desktop（Tauri/Electron）**：僅在桌面版本中開放 Key 存放與 Provider allowlist 管理。
+- **玩家驗證**：建議玩家透過防火牆或啟用離線模式確認遊戲確實不會對外連線。

--- a/src/core/AiOrchestrator.ts
+++ b/src/core/AiOrchestrator.ts
@@ -1,5 +1,6 @@
 import type { GhostOption, Spirit, WordCard, WorldStateData } from './Types';
 import { seedFrom, type RandomGenerator } from './Seed';
+import type { GameSettings } from './Settings';
 
 export interface GhostOptionContext {
   spirit: Spirit;
@@ -10,6 +11,11 @@ export interface GhostOptionContext {
 
 export class AiOrchestrator {
   mode: 'local' | 'provider' = 'local';
+  private readonly settings?: GameSettings;
+
+  constructor(settings?: GameSettings) {
+    this.settings = settings;
+  }
 
   async genGhostOptions({ seed }: GhostOptionContext): Promise<{ options: GhostOption[]; tone: string }> {
     if (this.mode !== 'local') {
@@ -34,9 +40,21 @@ export class AiOrchestrator {
   }
 
   private buildLocalOptions(random: RandomGenerator): GhostOption[] {
-    const variants: Array<Omit<GhostOption, 'text'> & { textVariants: string[] }> = [
+    const soften = this.settings?.isSoftLanguageEnabled() ?? false;
+    const variants: Array<
+      Omit<GhostOption, 'text'> & { textVariants: string[]; softenTextVariants?: string[] }
+    > = [
       {
-        textVariants: ['讓我替你把名冊找正好嗎？', '要不要我幫你把名冊整理正好？', '我可以替你把名冊整理妥當。'],
+        textVariants: [
+          '讓我替你把名冊找正好嗎？',
+          '要不要我幫你把名冊整理正好？',
+          '我可以替你把名冊整理妥當。'
+        ],
+        softenTextVariants: [
+          '我來幫你把名冊慢慢整理好嗎？',
+          '要不要我陪你把名冊一頁頁排整齊？',
+          '我可以溫柔地替你把名冊整理好。'
+        ],
         type: '指認',
         targets: ['e1'],
         requires: [],
@@ -44,7 +62,16 @@ export class AiOrchestrator {
         hint: '碼頭管理處'
       },
       {
-        textVariants: ['我帶王嬸的佛珠，她掛念你。', '王嬸託我帶來佛珠，她很想你。', '我拿著王嬸的佛珠，她惦記著你。'],
+        textVariants: [
+          '我帶王嬸的佛珠，她掛念你。',
+          '王嬸託我帶來佛珠，她很想你。',
+          '我拿著王嬸的佛珠，她惦記著你。'
+        ],
+        softenTextVariants: [
+          '我帶來王嬸托付的佛珠，她一直惦記著你。',
+          '王嬸請我帶著這串佛珠來，她說很想念你。',
+          '我握著王嬸的佛珠，她滿心希望你能安心。'
+        ],
         type: '安撫',
         targets: [],
         requires: ['it_wang_beads'],
@@ -53,10 +80,12 @@ export class AiOrchestrator {
     ];
 
     const options = variants.map((variant) => {
-      const choice = Math.floor(random() * variant.textVariants.length);
-      const text = variant.textVariants[Math.max(0, Math.min(choice, variant.textVariants.length - 1))];
+      const pool = soften && variant.softenTextVariants?.length ? variant.softenTextVariants : variant.textVariants;
+      const choice = Math.floor(random() * pool.length);
+      const text = pool[Math.max(0, Math.min(choice, pool.length - 1))];
       const { textVariants: _ignored, ...rest } = variant;
-      return { ...rest, text } satisfies GhostOption;
+      const { softenTextVariants: _ignoredSoft, ...base } = rest;
+      return { ...base, text } satisfies GhostOption;
     });
 
     return this.shuffle(options, random);

--- a/src/core/AiOrchestrator.ts
+++ b/src/core/AiOrchestrator.ts
@@ -1,6 +1,8 @@
 import type { GhostOption, Spirit, WordCard, WorldStateData } from './Types';
 import { seedFrom, type RandomGenerator } from './Seed';
 import type { GameSettings } from './Settings';
+import type { ProviderAdapter } from './ProviderAdapter';
+import { WebProviderAdapter } from './ProviderAdapter';
 
 export interface GhostOptionContext {
   spirit: Spirit;
@@ -12,14 +14,18 @@ export interface GhostOptionContext {
 export class AiOrchestrator {
   mode: 'local' | 'provider' = 'local';
   private readonly settings?: GameSettings;
+  private readonly providerAdapter: ProviderAdapter;
 
-  constructor(settings?: GameSettings) {
+  constructor(settings?: GameSettings, providerAdapter: ProviderAdapter = new WebProviderAdapter()) {
     this.settings = settings;
+    this.providerAdapter = providerAdapter;
   }
 
-  async genGhostOptions({ seed }: GhostOptionContext): Promise<{ options: GhostOption[]; tone: string }> {
-    if (this.mode !== 'local') {
-      throw new Error('Remote provider 尚未實作。');
+  async genGhostOptions(context: GhostOptionContext): Promise<{ options: GhostOption[]; tone: string }> {
+    const { seed } = context;
+    if (this.mode === 'provider') {
+      const response = await this.providerAdapter.requestChatJSON(context);
+      return response as { options: GhostOption[]; tone: string };
     }
 
     const random = this.createRandom(seed ?? '');

--- a/src/core/ProviderAdapter.ts
+++ b/src/core/ProviderAdapter.ts
@@ -1,0 +1,9 @@
+export interface ProviderAdapter {
+  requestChatJSON(promptBundle: unknown): Promise<any>;
+}
+
+export class WebProviderAdapter implements ProviderAdapter {
+  async requestChatJSON(): Promise<any> {
+    throw new Error('Provider disabled in web build');
+  }
+}

--- a/src/core/Settings.ts
+++ b/src/core/Settings.ts
@@ -1,0 +1,159 @@
+import Phaser from 'phaser';
+import type { WorldState } from './WorldState';
+
+export interface GameSettingsData {
+  textSpeed: number;
+  softenLanguage: boolean;
+  offlineMode: boolean;
+}
+
+export const DEFAULT_TEXT_SPEED = 18;
+export const MIN_TEXT_SPEED = 6;
+export const MAX_TEXT_SPEED = 80;
+
+const DEFAULT_SETTINGS: GameSettingsData = {
+  textSpeed: DEFAULT_TEXT_SPEED,
+  softenLanguage: false,
+  offlineMode: false
+};
+
+export type GameSettingsChangeEvent =
+  | { type: 'textSpeed'; value: number }
+  | { type: 'softenLanguage'; value: boolean }
+  | { type: 'offlineMode'; value: boolean };
+
+export class GameSettings extends Phaser.Events.EventEmitter {
+  private readonly storage: Storage | null;
+  private readonly key: string;
+  private data: GameSettingsData = { ...DEFAULT_SETTINGS };
+
+  constructor(storage?: Storage | null, key = 'yishi:settings') {
+    super();
+    if (storage !== undefined) {
+      this.storage = storage;
+    } else if (typeof window !== 'undefined' && window.localStorage) {
+      this.storage = window.localStorage;
+    } else {
+      this.storage = null;
+    }
+    this.key = key;
+  }
+
+  async load(): Promise<void> {
+    if (!this.storage) {
+      return;
+    }
+
+    const raw = this.storage.getItem(this.key);
+    if (!raw) {
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(raw) as Partial<GameSettingsData>;
+      this.data = {
+        ...DEFAULT_SETTINGS,
+        ...parsed
+      };
+      this.data.textSpeed = Math.round(
+        Math.min(Math.max(this.data.textSpeed ?? DEFAULT_TEXT_SPEED, MIN_TEXT_SPEED), MAX_TEXT_SPEED)
+      );
+      this.data.softenLanguage = Boolean(this.data.softenLanguage);
+      this.data.offlineMode = Boolean(this.data.offlineMode);
+    } catch (error) {
+      console.error('讀取設定失敗', error);
+      this.data = { ...DEFAULT_SETTINGS };
+    }
+  }
+
+  save(): void {
+    if (!this.storage) {
+      return;
+    }
+
+    try {
+      this.storage.setItem(this.key, JSON.stringify(this.data));
+    } catch (error) {
+      console.error('儲存設定失敗', error);
+    }
+  }
+
+  getSnapshot(): GameSettingsData {
+    return { ...this.data };
+  }
+
+  getTextSpeed(): number {
+    return this.data.textSpeed;
+  }
+
+  setTextSpeed(speed: number, persist = true): void {
+    const clamped = Math.round(Math.min(Math.max(speed, MIN_TEXT_SPEED), MAX_TEXT_SPEED));
+    if (clamped === this.data.textSpeed) {
+      if (persist) {
+        this.save();
+      }
+      return;
+    }
+    this.data.textSpeed = clamped;
+    if (persist) {
+      this.save();
+    }
+    this.emitChange({ type: 'textSpeed', value: clamped });
+  }
+
+  isSoftLanguageEnabled(): boolean {
+    return this.data.softenLanguage;
+  }
+
+  setSoftLanguage(enabled: boolean, persist = true): void {
+    if (enabled === this.data.softenLanguage) {
+      if (persist) {
+        this.save();
+      }
+      return;
+    }
+    this.data.softenLanguage = enabled;
+    if (persist) {
+      this.save();
+    }
+    this.emitChange({ type: 'softenLanguage', value: enabled });
+  }
+
+  isOfflineMode(): boolean {
+    return this.data.offlineMode;
+  }
+
+  setOfflineMode(enabled: boolean, persist = true): void {
+    if (enabled === this.data.offlineMode) {
+      if (persist) {
+        this.save();
+      }
+      return;
+    }
+    this.data.offlineMode = enabled;
+    if (persist) {
+      this.save();
+    }
+    this.emitChange({ type: 'offlineMode', value: enabled });
+  }
+
+  applyWorldFlags(world: WorldState): void {
+    world.setFlag('offline', this.data.offlineMode);
+  }
+
+  private emitChange(event: GameSettingsChangeEvent): void {
+    switch (event.type) {
+      case 'textSpeed':
+        this.emit('change:textSpeed', event.value);
+        break;
+      case 'softenLanguage':
+        this.emit('change:softenLanguage', event.value);
+        break;
+      case 'offlineMode':
+        this.emit('change:offlineMode', event.value);
+        break;
+      default:
+        break;
+    }
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import MediationScene from './scenes/MediationScene';
 import InventoryScene from './scenes/InventoryScene';
 import WordCardsScene from './scenes/WordCardsScene';
 import HintsScene from './scenes/HintsScene';
+import SettingsScene from './scenes/SettingsScene';
 import LoadScene from './scenes/LoadScene';
 
 const config: Phaser.Types.Core.GameConfig = {
@@ -20,6 +21,7 @@ const config: Phaser.Types.Core.GameConfig = {
     BootScene, TitleScene, ShellScene, MapScene,
     StoryScene, GhostCommScene, MediationScene,
     InventoryScene, WordCardsScene, HintsScene,
+    SettingsScene,
     LoadScene
   ]
 };

--- a/src/scenes/BootScene.ts
+++ b/src/scenes/BootScene.ts
@@ -7,6 +7,7 @@ import { bus } from '@core/EventBus';
 import { LocalStorageSaver } from '@core/Saver';
 import AutoSave from '@core/AutoSave';
 import { DataValidator } from '@core/DataValidator';
+import { GameSettings } from '@core/Settings';
 
 export default class BootScene extends Phaser.Scene {
   constructor(){ super('BootScene'); }
@@ -42,14 +43,20 @@ export default class BootScene extends Phaser.Scene {
       return;
     }
 
+    const settings = new GameSettings();
+    await settings.load();
+
     const world  = new WorldState();
-    const aio    = new AiOrchestrator();
+    settings.applyWorldFlags(world);
+
+    const aio    = new AiOrchestrator(settings);
     const saver  = new LocalStorageSaver(world);
     AutoSave.install(bus, saver);
 
     this.game.registry.set('router', router);
     this.game.registry.set('repo', repo);
     this.game.registry.set('world', world);
+    this.game.registry.set('settings', settings);
     this.game.registry.set('aio', aio);
     this.game.registry.set('bus', bus);
     this.game.registry.set('saver', saver);

--- a/src/scenes/SettingsScene.ts
+++ b/src/scenes/SettingsScene.ts
@@ -1,0 +1,272 @@
+import Phaser from 'phaser';
+import { ModuleScene } from '@core/Router';
+import { GameSettings, MIN_TEXT_SPEED, MAX_TEXT_SPEED } from '@core/Settings';
+import type { WorldState } from '@core/WorldState';
+
+export default class SettingsScene extends ModuleScene<void, void> {
+  private settings?: GameSettings;
+  private world?: WorldState;
+  private draggingHandle = false;
+  private sliderTrack?: Phaser.GameObjects.Rectangle;
+  private sliderHandle?: Phaser.GameObjects.Arc;
+  private speedLabel?: Phaser.GameObjects.Text;
+  private dragHandler?: (pointer: Phaser.Input.Pointer, gameObject: Phaser.GameObjects.GameObject, dragX: number) => void;
+  private dragEndHandler?: (pointer: Phaser.Input.Pointer) => void;
+  private textSpeedListener?: (value: number) => void;
+  private softLanguageListener?: (value: boolean) => void;
+  private offlineListener?: (value: boolean) => void;
+
+  constructor() {
+    super('SettingsScene');
+  }
+
+  create() {
+    this.settings = this.registry.get('settings') as GameSettings | undefined;
+    this.world = this.registry.get('world') as WorldState | undefined;
+
+    if (!this.settings) {
+      this.done(undefined as void);
+      return;
+    }
+
+    const { width, height } = this.scale;
+
+    this.add.text(width / 2, 64, '設定', { fontSize: '32px', color: '#fff' }).setOrigin(0.5);
+    this.add
+      .text(width / 2, 110, '調整遊戲體驗偏好。', {
+        fontSize: '18px',
+        color: '#ccc'
+      })
+      .setOrigin(0.5);
+
+    this.buildTextSpeedSlider(width / 2, 200);
+    this.buildSoftLanguageToggle(width / 2, 320);
+    this.buildOfflineToggle(width / 2, 380);
+
+    const closeButton = this.add
+      .text(width / 2, height - 80, '返回', { fontSize: '24px', color: '#aaf' })
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true });
+
+    closeButton.on('pointerup', () => {
+      this.done(undefined as void);
+    });
+
+    this.events.once(Phaser.Scenes.Events.SHUTDOWN, this.cleanup, this);
+    this.events.once(Phaser.Scenes.Events.DESTROY, this.cleanup, this);
+  }
+
+  private buildTextSpeedSlider(centerX: number, y: number) {
+    if (!this.settings) {
+      return;
+    }
+
+    this.add.text(centerX - 220, y - 70, '文字速度', { fontSize: '22px', color: '#fff' }).setOrigin(0, 0.5);
+
+    const trackWidth = 360;
+    const trackHeight = 4;
+    const trackX = centerX - trackWidth / 2;
+
+    this.sliderTrack = this.add
+      .rectangle(trackX, y, trackWidth, trackHeight, 0xffffff, 0.3)
+      .setOrigin(0, 0.5)
+      .setInteractive({ useHandCursor: true });
+
+    this.sliderHandle = this.add
+      .arc(0, y, 12, 0, 360, false, 0xffffff, 1)
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true });
+
+    this.input.setDraggable(this.sliderHandle);
+
+    const speed = this.settings.getTextSpeed();
+
+    this.speedLabel = this.add.text(centerX + trackWidth / 2 + 16, y, '', {
+      fontSize: '18px',
+      color: '#fff'
+    });
+    this.speedLabel.setOrigin(0, 0.5);
+
+    const applyPosition = (posX: number, persist = true) => {
+      if (!this.settings) {
+        return;
+      }
+      const ratio = Phaser.Math.Clamp((posX - trackX) / trackWidth, 0, 1);
+      const speedValue = Math.round(MIN_TEXT_SPEED + (MAX_TEXT_SPEED - MIN_TEXT_SPEED) * ratio);
+      this.settings.setTextSpeed(speedValue, persist);
+    };
+
+    const updateHandle = (value: number) => {
+      if (!this.sliderHandle) {
+        return;
+      }
+      const ratio = (value - MIN_TEXT_SPEED) / (MAX_TEXT_SPEED - MIN_TEXT_SPEED);
+      const clamped = Phaser.Math.Clamp(ratio, 0, 1);
+      const posX = trackX + clamped * trackWidth;
+      this.sliderHandle.setPosition(posX, y);
+      this.updateSpeedLabel(value);
+    };
+
+    updateHandle(speed);
+
+    this.sliderTrack.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
+      const posX = Phaser.Math.Clamp(pointer.x, trackX, trackX + trackWidth);
+      this.sliderHandle?.setPosition(posX, y);
+      this.updateSpeedLabel(this.positionToSpeed(posX, trackX, trackWidth));
+      applyPosition(posX);
+    });
+
+    if (this.sliderHandle) {
+      this.sliderHandle.on('pointerdown', () => {
+        this.draggingHandle = true;
+      });
+      this.sliderHandle.on('pointerup', () => {
+        if (this.draggingHandle) {
+          applyPosition(this.sliderHandle?.x ?? trackX);
+        }
+        this.draggingHandle = false;
+      });
+      this.sliderHandle.on('pointerout', () => {
+        this.draggingHandle = false;
+      });
+    }
+
+    this.dragHandler = (_pointer, gameObject, dragX) => {
+      if (!this.sliderHandle || gameObject !== this.sliderHandle) {
+        return;
+      }
+      const clamped = Phaser.Math.Clamp(dragX, trackX, trackX + trackWidth);
+      this.sliderHandle.setPosition(clamped, y);
+      this.updateSpeedLabel(this.positionToSpeed(clamped, trackX, trackWidth));
+      applyPosition(clamped, false);
+    };
+
+    this.dragEndHandler = (pointer) => {
+      if (!this.sliderHandle || !this.draggingHandle) {
+        return;
+      }
+      const clamped = Phaser.Math.Clamp(pointer.x, trackX, trackX + trackWidth);
+      this.sliderHandle.setPosition(clamped, y);
+      applyPosition(clamped);
+      this.draggingHandle = false;
+    };
+
+    this.input.on('drag', this.dragHandler);
+    this.input.on('dragend', this.dragEndHandler);
+
+    this.textSpeedListener = (value: number) => {
+      updateHandle(value);
+    };
+    this.settings.on('change:textSpeed', this.textSpeedListener);
+  }
+
+  private positionToSpeed(posX: number, trackX: number, trackWidth: number): number {
+    const ratio = Phaser.Math.Clamp((posX - trackX) / trackWidth, 0, 1);
+    return Math.round(MIN_TEXT_SPEED + (MAX_TEXT_SPEED - MIN_TEXT_SPEED) * ratio);
+  }
+
+  private updateSpeedLabel(speed: number) {
+    if (!this.speedLabel) {
+      return;
+    }
+    const charsPerSecond = 1000 / Math.max(speed, 1);
+    this.speedLabel.setText(`每字 ${speed} ms（約 ${charsPerSecond.toFixed(1)} 字/秒）`);
+  }
+
+  private buildSoftLanguageToggle(centerX: number, y: number) {
+    if (!this.settings) {
+      return;
+    }
+
+    const label = this.add
+      .text(centerX, y, '', { fontSize: '22px', color: '#fff' })
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true });
+
+    const updateText = () => {
+      const state = this.settings?.isSoftLanguageEnabled() ? '開' : '關';
+      label.setText(`柔化模式：${state}`);
+    };
+
+    this.softLanguageListener = () => {
+      updateText();
+    };
+    this.settings.on('change:softenLanguage', this.softLanguageListener);
+
+    label.on('pointerup', () => {
+      if (!this.settings) {
+        return;
+      }
+      const next = !this.settings.isSoftLanguageEnabled();
+      this.settings.setSoftLanguage(next);
+      updateText();
+    });
+
+    updateText();
+  }
+
+  private buildOfflineToggle(centerX: number, y: number) {
+    if (!this.settings) {
+      return;
+    }
+
+    const label = this.add
+      .text(centerX, y, '', { fontSize: '22px', color: '#fff' })
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true });
+
+    const updateText = () => {
+      const state = this.settings?.isOfflineMode() ? '開' : '關';
+      label.setText(`離線模式：${state}`);
+    };
+
+    this.offlineListener = () => {
+      updateText();
+    };
+    this.settings.on('change:offlineMode', this.offlineListener);
+
+    label.on('pointerup', () => {
+      if (!this.settings) {
+        return;
+      }
+      const next = !this.settings.isOfflineMode();
+      this.settings.setOfflineMode(next);
+      if (this.world) {
+        this.world.setFlag('offline', next);
+      }
+      updateText();
+    });
+
+    updateText();
+  }
+
+  private cleanup() {
+    if (this.sliderTrack) {
+      this.sliderTrack.removeAllListeners();
+    }
+
+    if (this.sliderHandle) {
+      this.sliderHandle.removeAllListeners();
+    }
+
+    if (this.dragHandler) {
+      this.input.off('drag', this.dragHandler);
+    }
+
+    if (this.dragEndHandler) {
+      this.input.off('dragend', this.dragEndHandler);
+    }
+
+    if (this.settings && this.textSpeedListener) {
+      this.settings.off('change:textSpeed', this.textSpeedListener);
+    }
+
+    if (this.settings && this.softLanguageListener) {
+      this.settings.off('change:softenLanguage', this.softLanguageListener);
+    }
+
+    if (this.settings && this.offlineListener) {
+      this.settings.off('change:offlineMode', this.offlineListener);
+    }
+  }
+}

--- a/src/scenes/ShellScene.ts
+++ b/src/scenes/ShellScene.ts
@@ -1,5 +1,6 @@
 import { ModuleScene, Router } from '@core/Router';
 import { WorldState } from '@core/WorldState';
+import MiasmaIndicator from '@ui/MiasmaIndicator';
 
 export default class ShellScene extends ModuleScene {
   constructor() {
@@ -18,11 +19,18 @@ export default class ShellScene extends ModuleScene {
       })
       .setOrigin(0, 0);
 
+    const miasmaIndicator = new MiasmaIndicator(this, width - 140, 110, {
+      width: 240,
+      height: 140
+    });
+    miasmaIndicator.setMiasma(world?.data?.煞氣 ?? '清');
+
     const updateHud = () => {
       const location = world?.data?.位置 ?? '';
       const sha = world?.data?.煞氣 ?? '';
       const yin = world?.data?.陰德 ?? '';
       hudText.setText(`位置：${location}\n煞氣：${sha}\n陰德：${yin}`);
+      miasmaIndicator.setMiasma(world?.data?.煞氣 ?? '清');
     };
 
     updateHud();

--- a/src/scenes/ShellScene.ts
+++ b/src/scenes/ShellScene.ts
@@ -92,5 +92,17 @@ export default class ShellScene extends ModuleScene {
     hintsButton.on('pointerup', () => {
       router.push('HintsScene');
     });
+
+    const settingsButton = this.add
+      .text(width / 2, height / 2 + 240, '設定', {
+        fontSize: '24px',
+        color: '#aaf'
+      })
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true });
+
+    settingsButton.on('pointerup', () => {
+      router.push('SettingsScene');
+    });
   }
 }

--- a/src/ui/DialogueBox.ts
+++ b/src/ui/DialogueBox.ts
@@ -1,0 +1,161 @@
+import Phaser from 'phaser';
+
+export interface DialogueBoxConfig {
+  width?: number;
+  height?: number;
+  padding?: number;
+  backgroundColor?: number;
+  backgroundAlpha?: number;
+  fontSize?: string;
+  textColor?: string;
+  typeSpeed?: number;
+}
+
+export default class DialogueBox extends Phaser.Events.EventEmitter {
+  readonly container: Phaser.GameObjects.Container;
+
+  private readonly scene: Phaser.Scene;
+
+  private readonly background: Phaser.GameObjects.Rectangle;
+
+  private readonly textObject: Phaser.GameObjects.Text;
+
+  private readonly padding: number;
+
+  private readonly typeSpeed: number;
+
+  private typingTimer?: Phaser.Time.TimerEvent;
+
+  private fullText = '';
+
+  private visibleText = '';
+
+  private charIndex = 0;
+
+  private completed = true;
+
+  private destroyed = false;
+
+  constructor(scene: Phaser.Scene, x: number, y: number, config: DialogueBoxConfig = {}) {
+    super();
+    this.scene = scene;
+    const width = config.width ?? 520;
+    const height = config.height ?? 160;
+    this.padding = config.padding ?? 16;
+    this.typeSpeed = config.typeSpeed ?? 18;
+
+    this.container = scene.add.container(x, y);
+    this.container.setSize(width, height);
+
+    this.background = scene.add
+      .rectangle(0, 0, width, height, config.backgroundColor ?? 0x000000, config.backgroundAlpha ?? 0.6)
+      .setOrigin(0, 0);
+
+    this.textObject = scene.add
+      .text(this.padding, this.padding, '', {
+        fontSize: config.fontSize ?? '20px',
+        color: config.textColor ?? '#fff',
+        wordWrap: { width: width - this.padding * 2 }
+      })
+      .setOrigin(0, 0);
+
+    this.container.add([this.background, this.textObject]);
+
+    scene.input.keyboard?.on('keydown-SPACE', this.handleSkipKey, this);
+    scene.events.once(Phaser.Scenes.Events.SHUTDOWN, this.destroy, this);
+    scene.events.once(Phaser.Scenes.Events.DESTROY, this.destroy, this);
+  }
+
+  setText(text: string) {
+    this.fullText = text ?? '';
+    this.visibleText = '';
+    this.charIndex = 0;
+    this.completed = !this.fullText.length;
+    this.textObject.setText('');
+    this.restartTyping();
+    if (this.completed) {
+      this.emit('complete', this.fullText);
+    } else {
+      this.emit('start', this.fullText);
+    }
+  }
+
+  skip() {
+    if (this.completed) {
+      return;
+    }
+    this.visibleText = this.fullText;
+    this.charIndex = this.fullText.length;
+    this.textObject.setText(this.visibleText);
+    this.finishTyping();
+  }
+
+  isComplete() {
+    return this.completed;
+  }
+
+  destroy() {
+    if (this.destroyed) {
+      return;
+    }
+    this.destroyed = true;
+    this.stopTyping();
+    this.scene.input.keyboard?.off('keydown-SPACE', this.handleSkipKey, this);
+    this.scene.events.off(Phaser.Scenes.Events.SHUTDOWN, this.destroy, this);
+    this.scene.events.off(Phaser.Scenes.Events.DESTROY, this.destroy, this);
+    this.container.destroy(true);
+    this.removeAllListeners();
+  }
+
+  private restartTyping() {
+    this.stopTyping();
+    if (!this.fullText.length) {
+      this.completed = true;
+      return;
+    }
+    this.completed = false;
+    this.typingTimer = this.scene.time.addEvent({
+      delay: this.typeSpeed,
+      loop: true,
+      callback: this.handleTypingStep,
+      callbackScope: this
+    });
+  }
+
+  private stopTyping() {
+    if (this.typingTimer) {
+      this.typingTimer.remove(false);
+      this.typingTimer.destroy();
+      this.typingTimer = undefined;
+    }
+  }
+
+  private handleTypingStep() {
+    if (this.charIndex >= this.fullText.length) {
+      this.finishTyping();
+      return;
+    }
+    this.visibleText += this.fullText.charAt(this.charIndex);
+    this.charIndex += 1;
+    this.textObject.setText(this.visibleText);
+    if (this.charIndex >= this.fullText.length) {
+      this.finishTyping();
+    }
+  }
+
+  private finishTyping() {
+    this.stopTyping();
+    if (this.completed) {
+      return;
+    }
+    this.completed = true;
+    this.emit('complete', this.fullText);
+  }
+
+  private handleSkipKey() {
+    if (!this.scene.input.enabled) {
+      return;
+    }
+    this.skip();
+  }
+}

--- a/src/ui/MiasmaIndicator.ts
+++ b/src/ui/MiasmaIndicator.ts
@@ -1,0 +1,150 @@
+import Phaser from 'phaser';
+import type { Miasma } from '@core/Types';
+
+export interface MiasmaIndicatorConfig {
+  width?: number;
+  height?: number;
+  label?: string;
+  backgroundColor?: number;
+  backgroundAlpha?: number;
+  fogTint?: number;
+  textColor?: string;
+  valueFontSize?: string;
+}
+
+type MiasmaSetting = {
+  alpha: number;
+  offset: number;
+  duration: number;
+};
+
+const SETTINGS: Record<Miasma, MiasmaSetting> = {
+  清: { alpha: 0.28, offset: 8, duration: 5200 },
+  濁: { alpha: 0.46, offset: 14, duration: 3800 },
+  沸: { alpha: 0.68, offset: 22, duration: 2600 }
+};
+
+export default class MiasmaIndicator {
+  readonly container: Phaser.GameObjects.Container;
+
+  private readonly scene: Phaser.Scene;
+
+  private readonly background: Phaser.GameObjects.Rectangle;
+
+  private readonly fog: Phaser.GameObjects.Image;
+
+  private readonly valueText: Phaser.GameObjects.Text;
+
+  private readonly labelText: Phaser.GameObjects.Text;
+
+  private current: Miasma = '清';
+
+  private motionTween?: Phaser.Tweens.Tween;
+
+  private destroyed = false;
+
+  constructor(scene: Phaser.Scene, x: number, y: number, config: MiasmaIndicatorConfig = {}) {
+    this.scene = scene;
+    const width = config.width ?? 200;
+    const height = config.height ?? 120;
+    const label = config.label ?? '煞氣';
+    const backgroundColor = config.backgroundColor ?? 0x000000;
+    const backgroundAlpha = config.backgroundAlpha ?? 0.45;
+    const textColor = config.textColor ?? '#fff';
+    const valueFontSize = config.valueFontSize ?? '28px';
+
+    this.container = scene.add.container(x, y);
+    this.container.setSize(width, height);
+
+    this.background = scene.add.rectangle(0, 0, width, height, backgroundColor, backgroundAlpha).setOrigin(0.5);
+
+    this.labelText = scene.add
+      .text(0, -height / 2 + 12, label, {
+        fontSize: '18px',
+        color: textColor
+      })
+      .setOrigin(0.5, 0);
+
+    MiasmaIndicator.ensureTexture(scene);
+    this.fog = scene.add
+      .image(0, 8, MiasmaIndicator.TEXTURE_KEY)
+      .setDisplaySize(width - 24, height - 48)
+      .setAlpha(0)
+      .setTint(config.fogTint ?? 0xc7d5ff)
+      .setBlendMode(Phaser.BlendModes.ADD)
+      .setOrigin(0.5);
+
+    this.valueText = scene.add
+      .text(0, height / 2 - 48, '', {
+        fontSize: valueFontSize,
+        color: textColor
+      })
+      .setOrigin(0.5, 0);
+
+    this.container.add([this.background, this.fog, this.labelText, this.valueText]);
+
+    scene.events.once(Phaser.Scenes.Events.SHUTDOWN, this.destroy, this);
+    scene.events.once(Phaser.Scenes.Events.DESTROY, this.destroy, this);
+  }
+
+  setMiasma(level: Miasma) {
+    if (this.current === level && this.motionTween) {
+      return;
+    }
+    this.current = level;
+    const setting = SETTINGS[level];
+    this.valueText.setText(level);
+    this.fog.setAlpha(setting.alpha);
+    this.applyMotion(setting);
+  }
+
+  destroy() {
+    if (this.destroyed) {
+      return;
+    }
+    this.destroyed = true;
+    this.motionTween?.stop();
+    this.motionTween?.remove();
+    this.motionTween = undefined;
+    this.container.destroy(true);
+    this.scene.events.off(Phaser.Scenes.Events.SHUTDOWN, this.destroy, this);
+    this.scene.events.off(Phaser.Scenes.Events.DESTROY, this.destroy, this);
+  }
+
+  private applyMotion(setting: MiasmaSetting) {
+    this.motionTween?.stop();
+    this.motionTween?.remove();
+    const offset = setting.offset;
+    const duration = setting.duration;
+    this.fog.setPosition(0, 8);
+    this.motionTween = this.scene.tweens.add({
+      targets: this.fog,
+      x: { from: -offset, to: offset },
+      y: { from: 8 + offset * 0.3, to: 8 - offset * 0.3 },
+      duration,
+      ease: 'Sine.easeInOut',
+      yoyo: true,
+      repeat: -1
+    });
+  }
+
+  private static ensureTexture(scene: Phaser.Scene) {
+    if (scene.textures.exists(MiasmaIndicator.TEXTURE_KEY)) {
+      return;
+    }
+    const size = 256;
+    const graphics = scene.add.graphics({ x: 0, y: 0 });
+    graphics.setVisible(false);
+    const baseAlpha = 0.12;
+    graphics.fillStyle(0xffffff, baseAlpha);
+    graphics.fillRect(0, 0, size, size);
+    graphics.fillStyle(0xffffff, baseAlpha * 1.8);
+    graphics.fillCircle(size * 0.3, size * 0.3, size * 0.28);
+    graphics.fillCircle(size * 0.7, size * 0.35, size * 0.26);
+    graphics.fillCircle(size * 0.52, size * 0.68, size * 0.24);
+    graphics.generateTexture(MiasmaIndicator.TEXTURE_KEY, size, size);
+    graphics.destroy();
+  }
+
+  private static readonly TEXTURE_KEY = 'ui-miasma-fog';
+}

--- a/src/ui/OptionList.ts
+++ b/src/ui/OptionList.ts
@@ -1,0 +1,243 @@
+import Phaser from 'phaser';
+
+export interface OptionListItem<T = unknown> {
+  id?: string;
+  label: string;
+  data?: T;
+}
+
+export interface OptionListConfig {
+  width?: number;
+  spacing?: number;
+  fontSize?: string;
+  align?: 'left' | 'center' | 'right';
+  wrapWidth?: number;
+  textColor?: string;
+  highlightColor?: string;
+  disabledColor?: string;
+  messageColor?: string;
+}
+
+type Mode = 'options' | 'message';
+
+export default class OptionList<T = unknown> extends Phaser.Events.EventEmitter {
+  readonly container: Phaser.GameObjects.Container;
+
+  private readonly scene: Phaser.Scene;
+
+  private readonly config: Required<OptionListConfig> & { spacing: number; wrapWidth: number };
+
+  private items: OptionListItem<T>[] = [];
+
+  private textObjects: Phaser.GameObjects.Text[] = [];
+
+  private selectedIndex = -1;
+
+  private mode: Mode = 'message';
+
+  private destroyed = false;
+
+  constructor(scene: Phaser.Scene, x: number, y: number, config: OptionListConfig = {}) {
+    super();
+    this.scene = scene;
+    this.config = {
+      width: config.width ?? 260,
+      spacing: config.spacing ?? 42,
+      fontSize: config.fontSize ?? '18px',
+      align: config.align ?? 'center',
+      wrapWidth: config.wrapWidth ?? config.width ?? 260,
+      textColor: config.textColor ?? '#aaf',
+      highlightColor: config.highlightColor ?? '#fff',
+      disabledColor: config.disabledColor ?? '#888',
+      messageColor: config.messageColor ?? '#ccc'
+    };
+    this.container = scene.add.container(x, y);
+
+    scene.input.keyboard?.on('keydown-UP', this.handleCursorUp, this);
+    scene.input.keyboard?.on('keydown-DOWN', this.handleCursorDown, this);
+    scene.input.keyboard?.on('keydown-ENTER', this.handleConfirmKey, this);
+
+    scene.events.once(Phaser.Scenes.Events.SHUTDOWN, this.destroy, this);
+    scene.events.once(Phaser.Scenes.Events.DESTROY, this.destroy, this);
+  }
+
+  setOptions(items: OptionListItem<T>[]) {
+    this.mode = 'options';
+    this.items = items.slice();
+    this.selectedIndex = this.items.length ? Math.min(Math.max(this.selectedIndex, 0), this.items.length - 1) : -1;
+    if (this.items.length === 0) {
+      this.selectedIndex = -1;
+    }
+    this.rebuildTexts(this.items.map((item) => ({ content: item.label, interactive: true })), false);
+    if (this.items.length) {
+      this.setSelectedIndex(this.selectedIndex === -1 ? 0 : this.selectedIndex);
+    } else {
+      this.updateSelection();
+    }
+  }
+
+  setMessage(message: string | string[]) {
+    const lines = Array.isArray(message) ? message : [message];
+    this.mode = 'message';
+    this.items = [];
+    this.selectedIndex = -1;
+    this.rebuildTexts(lines.map((line) => ({ content: line, interactive: false })), true);
+  }
+
+  moveSelection(delta: number) {
+    if (this.mode !== 'options' || !this.items.length) {
+      return;
+    }
+    const total = this.items.length;
+    const current = this.selectedIndex < 0 ? (delta > 0 ? 0 : total - 1) : this.selectedIndex;
+    const next = (current + delta + total) % total;
+    this.setSelectedIndex(next);
+  }
+
+  confirmSelection() {
+    if (this.mode !== 'options' || this.selectedIndex < 0) {
+      return;
+    }
+    const item = this.items[this.selectedIndex];
+    if (!item) {
+      return;
+    }
+    this.emit('confirm', item, this.selectedIndex);
+  }
+
+  destroy() {
+    if (this.destroyed) {
+      return;
+    }
+    this.destroyed = true;
+    this.scene.input.keyboard?.off('keydown-UP', this.handleCursorUp, this);
+    this.scene.input.keyboard?.off('keydown-DOWN', this.handleCursorDown, this);
+    this.scene.input.keyboard?.off('keydown-ENTER', this.handleConfirmKey, this);
+    this.scene.events.off(Phaser.Scenes.Events.SHUTDOWN, this.destroy, this);
+    this.scene.events.off(Phaser.Scenes.Events.DESTROY, this.destroy, this);
+    this.clearTexts();
+    this.container.destroy(true);
+    this.removeAllListeners();
+  }
+
+  private rebuildTexts(entries: { content: string; interactive: boolean }[], isMessage: boolean) {
+    this.clearTexts();
+    const spacing = isMessage ? Math.max(this.config.spacing * 0.7, 26) : this.config.spacing;
+    entries.forEach((entry, index) => {
+      const text = this.createText(entry.content, index * spacing, isMessage);
+      if (entry.interactive) {
+        text.setInteractive({ useHandCursor: true });
+        text.on('pointerover', () => {
+          this.setSelectedIndex(index);
+        });
+        text.on('pointerup', () => {
+          this.setSelectedIndex(index);
+          this.confirmSelection();
+        });
+      }
+      this.textObjects.push(text);
+    });
+    this.updateSelection();
+  }
+
+  private createText(content: string, y: number, isMessage: boolean) {
+    const originX = this.getOriginX();
+    const baseX = this.getBaseX(originX);
+    const color = isMessage ? this.config.messageColor : this.config.textColor;
+    const text = this.scene.add
+      .text(baseX, y, content, {
+        fontSize: this.config.fontSize,
+        color,
+        align: this.config.align,
+        wordWrap: { width: this.config.wrapWidth }
+      })
+      .setOrigin(originX, 0);
+    this.container.add(text);
+    return text;
+  }
+
+  private clearTexts() {
+    this.textObjects.forEach((text) => {
+      text.removeAllListeners();
+      text.destroy();
+    });
+    this.textObjects = [];
+  }
+
+  private getOriginX() {
+    switch (this.config.align) {
+      case 'left':
+        return 0;
+      case 'right':
+        return 1;
+      default:
+        return 0.5;
+    }
+  }
+
+  private getBaseX(originX: number) {
+    if (originX === 0.5) {
+      return 0;
+    }
+    if (originX === 1) {
+      return this.config.width / 2;
+    }
+    return -this.config.width / 2;
+  }
+
+  private setSelectedIndex(index: number) {
+    if (this.mode !== 'options') {
+      this.selectedIndex = -1;
+      this.updateSelection();
+      return;
+    }
+    if (index < 0 || index >= this.items.length) {
+      this.selectedIndex = -1;
+      this.updateSelection();
+      return;
+    }
+    if (this.selectedIndex === index) {
+      return;
+    }
+    this.selectedIndex = index;
+    this.updateSelection();
+    const item = this.items[index];
+    if (item) {
+      this.emit('change', item, index);
+    }
+  }
+
+  private updateSelection() {
+    if (this.mode !== 'options') {
+      this.textObjects.forEach((text) => {
+        text.setStyle({ color: this.config.messageColor });
+        text.setAlpha(1);
+      });
+      return;
+    }
+    this.textObjects.forEach((text, idx) => {
+      if (idx === this.selectedIndex) {
+        text.setStyle({ color: this.config.highlightColor });
+        text.setAlpha(1);
+      } else {
+        text.setStyle({ color: this.config.textColor });
+        text.setAlpha(0.85);
+      }
+    });
+  }
+
+  private handleCursorUp() {
+    this.moveSelection(-1);
+  }
+
+  private handleCursorDown() {
+    this.moveSelection(1);
+  }
+
+  private handleConfirmKey() {
+    if (!this.scene.input.enabled) {
+      return;
+    }
+    this.confirmSelection();
+  }
+}


### PR DESCRIPTION
## Summary
- implement a reusable DialogueBox with typewriter reveal and spacebar skip support
- add a keyboard-friendly OptionList component and hook it into the ghost communication options panel
- create a MiasmaIndicator overlay and display it in GhostCommScene and ShellScene to mirror world data

## Testing
- npm run build *(fails: missing ajv dependencies in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68d87c333b64832ea53b2b428474acfc