### PR TITLE
Add screen effects to story steps and improve transitions

### DIFF
--- a/schemas/story.schema.json
+++ b/schemas/story.schema.json
@@ -73,6 +73,18 @@
             {
               "type": "object",
               "additionalProperties": false,
+              "required": ["t", "effectId"],
+              "properties": {
+                "t": { "const": "SCREEN_EFFECT" },
+                "effectId": { "type": "string" },
+                "duration": { "type": "number", "minimum": 0 },
+                "color": { "type": "string" },
+                "lineId": { "type": "string" }
+              }
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
               "required": ["t"],
               "properties": {
                 "t": { "const": "END" },

--- a/src/core/DataValidator.ts
+++ b/src/core/DataValidator.ts
@@ -1,5 +1,5 @@
 import Ajv from 'ajv/dist/2020';
-import type { ErrorObject, ValidateFunction } from 'ajv';
+import type { AnySchema, ErrorObject, ValidateFunction } from 'ajv';
 import addFormats from 'ajv-formats';
 import sacredItemSchema from '../../schemas/sacred-item.schema.json' assert { type: 'json' };
 import wordcardSchema from '../../schemas/wordcard.schema.json' assert { type: 'json' };
@@ -18,7 +18,7 @@ type SchemaName =
   | 'story'
   | 'map';
 
-const SCHEMAS: Record<SchemaName, unknown> = {
+const SCHEMAS: Record<SchemaName, AnySchema> = {
   'sacred-item': sacredItemSchema,
   'wordcard': wordcardSchema,
   'npc': npcSchema,
@@ -37,7 +37,7 @@ export class DataValidator {
     addFormats(this.ajv);
     this.validators = new Map();
 
-    for (const [name, schema] of Object.entries(SCHEMAS) as [SchemaName, unknown][]){
+    for (const [name, schema] of Object.entries(SCHEMAS) as [SchemaName, AnySchema][]){
       this.validators.set(name, this.ajv.compile(schema));
     }
   }

--- a/src/core/Types.ts
+++ b/src/core/Types.ts
@@ -18,6 +18,7 @@ export interface StoryNode {
         | {t:"CALL_MEDIATION"; npcId:string; lineId?:string}
         | {t:"GIVE_ITEM"; itemId:string; lineId?:string}
         | {t:"UPDATE_FLAG"; flag:string; value:any; lineId?:string}
+        | {t:"SCREEN_EFFECT"; effectId:string; duration?:number; color?:string; lineId?:string}
         | {t:"END"; lineId?:string}
         | {t:"CHOICE"; lineId?:string; options:(
               {action:"GOTO_LINE"; text:string; targetLineId:string; nextLineId?:string}


### PR DESCRIPTION
## Summary
- restore the text typewriter reveal and input handling in StoryScene and add a new SCREEN_EFFECT step with screen effect timing helpers
- extend shared story schemas/types for the SCREEN_EFFECT directive and adjust data validation typing to keep builds passing
- add fade in/out transitions when switching locations on the map for smoother scene changes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9c51fef98832eafd05ede985f4d0c