### PR TITLE
feat: integrate gpt provider with chinese docs

### DIFF
--- a/src/core/ProviderAdapter.ts
+++ b/src/core/ProviderAdapter.ts
@@ -1,9 +1,198 @@
+/**
+ * 提供與外部 AI 服務溝通的抽象介面，讓遊戲邏輯不必關心實際呼叫的 API 細節。
+ */
 export interface ProviderAdapter {
+  /**
+   * 將遊戲整理好的提示資料送出並期待取得 JSON 結果。
+   */
   requestChatJSON(promptBundle: unknown): Promise<any>;
+
+  /**
+   * 回報目前是否具有足夠資訊可以呼叫外部服務，例如 API Key 是否存在。
+   */
+  isReady(): boolean;
 }
 
+/**
+ * 針對網頁版本所設計的 OpenAI GPT 呼叫實作，會使用 Vite 的環境變數讀取 API 設定。
+ */
 export class WebProviderAdapter implements ProviderAdapter {
-  async requestChatJSON(): Promise<any> {
-    throw new Error('Provider disabled in web build');
+  /** 預設的 OpenAI Chat Completions API 位址。 */
+  private static readonly DEFAULT_API_URL = 'https://api.openai.com/v1/chat/completions';
+
+  /** 儲存 API Key，避免在多次呼叫時重複讀取環境變數。 */
+  private readonly apiKey?: string;
+
+  /** 可讓使用者覆寫的 API 位址，若未提供則使用預設值。 */
+  private readonly apiUrl: string;
+
+  /** 選擇呼叫的模型名稱，預設使用輕量級模型以降低成本。 */
+  private readonly model: string;
+
+  constructor(options?: { apiKey?: string; apiUrl?: string; model?: string }) {
+    // 自 Vite 的環境變數讀取設定，並允許於建構時覆寫。
+    this.apiKey = options?.apiKey ?? import.meta.env.VITE_OPENAI_API_KEY;
+    this.apiUrl = options?.apiUrl ?? import.meta.env.VITE_OPENAI_API_URL ?? WebProviderAdapter.DEFAULT_API_URL;
+    this.model = options?.model ?? import.meta.env.VITE_OPENAI_MODEL ?? 'gpt-4o-mini';
   }
+
+  /**
+   * 只要 API Key 為非空字串即可視為就緒；其餘狀況一律判定不可呼叫外部服務。
+   */
+  isReady(): boolean {
+    return Boolean(this.apiKey && this.apiKey.trim().length > 0);
+  }
+
+  /**
+   * 將遊戲上下文整理為提示後送給 OpenAI Chat Completions API，並解析為 JSON 回傳。
+   */
+  async requestChatJSON(promptBundle: unknown): Promise<any> {
+    if (!this.isReady()) {
+      throw new Error('OpenAI API 尚未設定 API Key，請在環境變數 VITE_OPENAI_API_KEY 中提供。');
+    }
+
+    const payload = this.buildPayload(promptBundle);
+
+    const response = await fetch(this.apiUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiKey}`
+      },
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`OpenAI API 回應失敗：${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    const json = (await response.json()) as OpenAIChatCompletionResponse;
+    const rawContent = json.choices?.[0]?.message?.content;
+
+    if (!rawContent) {
+      throw new Error('OpenAI API 沒有提供任何回覆內容。');
+    }
+
+    try {
+      return JSON.parse(rawContent);
+    } catch (error) {
+      throw new Error(`OpenAI 回傳內容無法解析成 JSON：${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  /**
+   * 將遊戲提供的上下文整理為最終送出的請求格式，包含系統提示、使用者提示與 JSON Schema。
+   */
+  private buildPayload(promptBundle: unknown): OpenAIChatCompletionPayload {
+    const contextText =
+      typeof promptBundle === 'string' ? promptBundle : JSON.stringify(promptBundle, null, 2);
+
+    const schema: OpenAIJSONSchema = {
+      name: 'ghost_comm_response',
+      schema: {
+        type: 'object',
+        required: ['tone', 'options'],
+        properties: {
+          tone: {
+            type: 'string',
+            description: '靈體在本回合對話中展現的語氣描述'
+          },
+          options: {
+            type: 'array',
+            minItems: 1,
+            maxItems: 4,
+            items: {
+              type: 'object',
+              required: ['text', 'type', 'targets', 'requires', 'effect'],
+              properties: {
+                text: {
+                  type: 'string',
+                  description: '顯示給玩家的對話內容'
+                },
+                type: {
+                  type: 'string',
+                  enum: ['安撫', '提問', '交換', '儀式', '指認']
+                },
+                targets: {
+                  type: 'array',
+                  items: { type: 'string' }
+                },
+                requires: {
+                  type: 'array',
+                  items: { type: 'string' }
+                },
+                effect: {
+                  type: 'string',
+                  enum: ['解結', '鬆動', '平煞', '條件交換', '觸怒']
+                },
+                hint: {
+                  type: 'string'
+                }
+              },
+              additionalProperties: false
+            }
+          }
+        },
+        additionalProperties: false
+      }
+    };
+
+    return {
+      model: this.model,
+      temperature: 0.6,
+      max_tokens: 700,
+      response_format: {
+        type: 'json_schema',
+        json_schema: schema
+      },
+      messages: [
+        {
+          role: 'system',
+          content:
+            '你是一位民俗靈異劇情設計助手，請根據提供的靈體資料與世界狀態，產生能推動劇情的回應選項。請務必以指定的 JSON Schema 回傳資料。'
+        },
+        {
+          role: 'user',
+          content: `以下是本回合的遊戲上下文，請輸出 JSON：\n${contextText}`
+        }
+      ]
+    };
+  }
+}
+
+/**
+ * OpenAI Chat Completions 回應的簡化型別定義，僅保留目前需要的欄位。
+ */
+interface OpenAIChatCompletionResponse {
+  choices?: Array<{
+    message?: {
+      content?: string;
+    };
+  }>;
+}
+
+/**
+ * OpenAI Chat Completions 要求所需的 JSON Schema 格式型別。
+ */
+interface OpenAIJSONSchema {
+  name: string;
+  schema: Record<string, unknown>;
+}
+
+/**
+ * 呼叫 Chat Completions API 時的請求負載定義。
+ */
+interface OpenAIChatCompletionPayload {
+  model: string;
+  temperature: number;
+  max_tokens: number;
+  response_format: {
+    type: 'json_schema';
+    json_schema: OpenAIJSONSchema;
+  };
+  messages: Array<{
+    role: 'system' | 'user';
+    content: string;
+  }>;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,30 +12,34 @@ import HintsScene from './scenes/HintsScene';
 import SettingsScene from './scenes/SettingsScene';
 import LoadScene from './scenes/LoadScene';
 
+/**
+ * Phaser 遊戲的全域設定，包含畫面大小、場景順序等資訊。
+ */
 const config: Phaser.Types.Core.GameConfig = {
   type: Phaser.AUTO,
   parent: 'game',
   backgroundColor: '#101010',
-  scale: { 
-    mode: Phaser.Scale.FIT, 
-    autoCenter: Phaser.Scale.CENTER_BOTH, 
-    width: 1280, 
-    height: 720 
+  scale: {
+    mode: Phaser.Scale.FIT,
+    autoCenter: Phaser.Scale.CENTER_BOTH,
+    width: 1280,
+    height: 720
   },
   scene: [
-    BootScene, 
-    TitleScene, 
+    BootScene,
+    TitleScene,
     IntroScene,  // 加入開頭場景
-    ShellScene, 
+    ShellScene,
     MapScene,
-    StoryScene, 
+    StoryScene,
     GhostCommScene,
-    InventoryScene, 
-    WordCardsScene, 
+    InventoryScene,
+    WordCardsScene,
     HintsScene,
     SettingsScene,
     LoadScene
   ]
 };
 
+// 建立遊戲實例並載入上述設定，從 BootScene 開始執行整個流程。
 new Phaser.Game(config);

--- a/src/scenes/BootScene.ts
+++ b/src/scenes/BootScene.ts
@@ -10,13 +10,24 @@ import { DataValidator } from '@core/DataValidator';
 import { GameSettings } from '@core/Settings';
 import AudioBus from '@core/AudioBus';
 
+/**
+ * 遊戲初始化場景，負責載入資料、檢查格式並建立各種核心服務。
+ */
 export default class BootScene extends Phaser.Scene {
   constructor(){ super('BootScene'); }
+
+  /**
+   * 可在此放置共用資源的預載邏輯，目前留空供未來擴充。
+   */
   preload(){ /* 可放字型/圖片 */ }
+
+  /**
+   * 建立核心物件、驗證資料並準備進入主選單。
+   */
   async create(){
-    const router = new Router(this.game);
-    const repo   = new DataRepo(async (p)=> (await (await fetch(p))).json());
-    const validator = new DataValidator();
+    const router = new Router(this.game); // 建立路由管理器，方便切換模組化場景。
+    const repo   = new DataRepo(async (p)=> (await (await fetch(p))).json()); // 讀取靜態資料的存取層。
+    const validator = new DataValidator(); // JSON Schema 驗證器，確保資料格式正確。
 
     const datasets = [
       { schema: 'sacred-item' as const, file: 'items', label: 'items.json' },
@@ -29,30 +40,32 @@ export default class BootScene extends Phaser.Scene {
 
     const validationErrors: string[] = [];
     for (const dataset of datasets){
-      const data = await repo.get(dataset.file);
-      const result = validator.validate(dataset.schema, data);
+      const data = await repo.get(dataset.file); // 從資料庫讀取每一份檔案。
+      const result = validator.validate(dataset.schema, data); // 驗證資料是否符合 Schema。
       if (!result.ok){
         const messages = result.errors ?? ['Unknown validation error'];
         for (const message of messages){
-          validationErrors.push(`${dataset.label}: ${message}`);
+          validationErrors.push(`${dataset.label}: ${message}`); // 將錯誤訊息收集起來供畫面顯示。
         }
       }
     }
 
     if (validationErrors.length > 0){
-      this.showValidationErrors(validationErrors);
+      this.showValidationErrors(validationErrors); // 若有錯誤則直接顯示報告並中止流程。
       return;
     }
 
-    const settings = new GameSettings();
-    await settings.load();
+    const settings = new GameSettings(); // 玩家設定儲存器。
+    await settings.load(); // 讀取本機設定。
 
-    const world  = new WorldState();
-    settings.applyWorldFlags(world);
+    const world  = new WorldState(); // 遊戲世界狀態容器。
+    settings.applyWorldFlags(world); // 將設定影響的旗標套用到世界狀態。
 
-    const aio    = new AiOrchestrator(settings);
-    const saver  = new LocalStorageSaver(world);
-    AutoSave.install(bus, saver);
+    const aio    = new AiOrchestrator(settings); // AI 管理器，會根據設定決定是否使用 GPT。
+    settings.on('change:offlineMode', () => aio.refreshMode()); // 當離線模式切換時同步更新 AI 模式。
+
+    const saver  = new LocalStorageSaver(world); // 負責寫入與讀取存檔。
+    AutoSave.install(bus, saver); // 安裝自動存檔機制。
 
     this.game.registry.set('router', router);
     this.game.registry.set('repo', repo);
@@ -63,9 +76,12 @@ export default class BootScene extends Phaser.Scene {
     this.game.registry.set('saver', saver);
     this.game.registry.set('audioBus', new AudioBus(this.sound));
 
-    this.scene.start('TitleScene');
+    this.scene.start('TitleScene'); // 一切就緒後切換到標題場景。
   }
 
+  /**
+   * 當資料檢查失敗時，在畫面上顯示清單提示開發者修正。
+   */
   private showValidationErrors(errors: string[]): void {
     this.cameras.main.setBackgroundColor(0x550000);
 

--- a/src/scenes/GhostCommScene.ts
+++ b/src/scenes/GhostCommScene.ts
@@ -11,6 +11,10 @@ import CardBoard from '@ui/CardBoard';
 import type { CardBoardItem } from '@ui/CardBoard';
 import { GhostDirector } from '@core/GhostDirector';
 
+/**
+ * 靈體溝通場景的核心類別，負責管理資料讀取、UI 建構以及與 AI 的互動流程。
+ */
+
 interface GhostCommResult {
   resolvedKnots?: string[];
   miasma?: string;
@@ -70,6 +74,9 @@ export default class GhostCommScene extends ModuleScene<{ spiritId: string }, Gh
     this.resetState();
   }
 
+  /**
+   * 進入場景時的初始化流程：讀取資料並構建所有 UI 元件。
+   */
   async create() {
     const spiritId = this.route?.in?.spiritId;
     this.repo = this.registry.get('repo') as DataRepo | undefined;
@@ -107,6 +114,9 @@ export default class GhostCommScene extends ModuleScene<{ spiritId: string }, Gh
     }
   }
 
+  /**
+   * 將場景內部狀態恢復成初始值，避免上一輪溝通的資料殘留。
+   */
   private resetState() {
     this.spirit = undefined;
     this.wordCards = [];
@@ -138,6 +148,9 @@ export default class GhostCommScene extends ModuleScene<{ spiritId: string }, Gh
     }
   }
 
+  /**
+   * 組裝對話框、卡牌區與選項列表等主要視覺元素。
+   */
   private buildLayout() {
     const { width, height } = this.scale;
 
@@ -571,6 +584,9 @@ export default class GhostCommScene extends ModuleScene<{ spiritId: string }, Gh
     });
   }
 
+  /**
+   * 玩家挑選字卡後會進入此流程，負責請求 AI 並顯示載入提示。
+   */
   private async handleWordCardSelected(card: WordCard) {
     if (!this.aio || !this.spirit || !this.world || this.loadingOptions) {
       return;


### PR DESCRIPTION
## Summary
- implement a web provider adapter that calls the OpenAI Chat Completions API using Vite environment variables and parse JSON responses
- refresh the AI orchestrator based on settings, add Chinese documentation comments, and link offline mode changes from the boot scene
- document the main game configuration and ghost communication scene workflow with Chinese comments for maintainers

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dbd84a826c832e87ccbf017844b7f5